### PR TITLE
Add ci-setup to bbs-master

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -39,4 +39,11 @@ filter:
         - themes/ddbasic/scripts/respond.*
         - themes/ddbasic/scripts/scalefix.js
         # Minified JavaScript files
-        - themes/ddbasic/scripts/*.min.js
+        - themes/ddbasic/scripts/*min.js
+        # Third party JavaScript libraries used in modules
+        - modules/ding_webtrends/js/webtrends*.js
+        - modules/ting_search_carousel/js/jquery.*
+        - modules/contrib/jquery_update/replace/ui/external/jquery.cookie*.js
+        - modules/ding_facetbrowser/js/jquery.cookie*.js
+        - modules/ding_toggle_format/js/jquery.cookie*.js
+        - modules/ding_tabroll/js/jquery-ui-tabs-rotate*.js

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,41 @@
+
+# Prepare a site-installation for testing
+circle-setup:
+	# Build profile using drush make
+	drush make ding2.make --no-core --contrib-destination=. -y
+	# Install theme dependencies
+	cd themes/ddbasic && npm install
+	# Process theme files.
+	# If there are any changes then fail the build. The result of processing
+	# should be committed along with the source changes.
+	cd themes/ddbasic && node_modules/.bin/gulp uglify sass
+	# Readable changes. Exclude minified CSS files compiled from SCSS. Changes
+	# in verbose version will probably also apply here.
+	git diff --exit-code -- . ':(exclude)themes/ddbasic/css/*.min.css'
+	# Do a complete diff in short form as well for good measure. This will
+	# catch changes in excluded files.
+	git diff --stat --exit-code
+	# Built an entire Drupal site with core, contrib and custom
+	# code First we build Drupal core only. Instead of using the
+	# profile specified in the make file we use the one we have
+	# just build. This way we do not have to update drupal.make
+	# for each build.
+	drush make drupal.make --projects=drupal -y $(DRUPAL_SITE_PATH)
+	# Copy the current profile which has just been built into Drupal core
+	mkdir $(DRUPAL_SITE_PATH)/profiles/ding2
+	cp -R ./* $(DRUPAL_SITE_PATH)/profiles/ding2/
+	# Install the site using the ding2 profile
+	cd $(DRUPAL_SITE_PATH) && drush site-install ding2 --db-url=mysql://ubuntu@127.0.0.1/circle_test -y
+
+# Run ding2 unittests
+circle-run-unit-tests:
+	cd $(DRUPAL_SITE_PATH)/profiles/ding2/modules/ding_test && composer install
+	cd $(DRUPAL_SITE_PATH) && drush en ding_test -y
+	# Run all ding unit-tests
+	mkdir -p $(CIRCLE_TEST_REPORTS)/phpunit
+	# Circleci has a proxy for the php-executable which confuses run-tests.sh,
+	# so we have to specify the full path to the executable.
+	# Tests to be run are referenced as a comma-seperated list of group-names.
+	cd $(DRUPAL_SITE_PATH) && php scripts/run-tests.sh --php /opt/circleci/.phpenv/shims/php --xml $(CIRCLE_TEST_REPORTS)/phpunit \
+	  "Ding! - Ting search unittest"
+

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ of the [TING concept](http://ting.dk).
 
 # Installation
 This README assumes that you have install a configured your server with a
-working Apache/Nginx, APC, Memcached, PHP 5.4 and Varnish 3.x (optional). The
+working Apache/Nginx, APC, Memcached, PHP 5.6 and Varnish 3.x (optional). The
 stack should be optimized to run a Drupal site.
 
 If you want to try out Ding2 you can download [the latest release](https://github.com/ding2/ding2/releases/latest). The `ding2-7.x-[version].tar.gz` file contain a full Drupal installation including Drupal Core, third party modules and Ding2 code needed to run the site.

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,7 @@
 machine:
   php:
-    # We support PHP 5.4 so choose the latest version supported by Circle.
-    version: 5.4.37
+    # We support PHP 5.6 so choose the latest version supported by Circle.
+    version: 5.6.22
   node:
     # Our frontend asset pipeline requires 0.12.0 or greater.
     version: 0.12.0
@@ -12,9 +12,9 @@ machine:
 dependencies:
   post:
     # Increase memory limit to 512M. This is required by ding2.
-    - echo "memory_limit = 512M" > ~/.phpenv/versions/$(phpenv global)/etc/conf.d/memory.ini
+    - echo "memory_limit = 512M" > /opt/circleci/.phpenv/versions/$(phpenv global)/etc/conf.d/memory.ini
     # Disable mail sending. Sendmail is not working on Circle.
-    - echo "sendmail_path = /bin/true" > ~/.phpenv/versions/$(phpenv global)/etc/conf.d/sendmail.ini
+    - echo "sendmail_path = /bin/true" > /opt/circleci/.phpenv/versions/$(phpenv global)/etc/conf.d/sendmail.ini
     # Clean up existing global composer installation. It contains dependencies
     # which do not match the PHP version we use. This prevents installation of
     # other packages.

--- a/circle.yml
+++ b/circle.yml
@@ -25,35 +25,16 @@ dependencies:
 
 test:
   override:
-    # Build profile using drush make
-    - drush make ding2.make --no-core --contrib-destination=. -y
-    # Install theme dependencies
-    - (cd themes/ddbasic && npm install)
-    # Process theme files.
-    # If there are any changes then fail the build. The result of processing
-    # should be committed along with the source changes.
-    - (cd themes/ddbasic && node_modules/.bin/gulp uglify sass)
-    # Readable changes. Exclude minified CSS files compiled from SCSS. Changes
-    # in verbose version will probably also apply here.
-    - git diff --exit-code -- . ':(exclude)themes/ddbasic/css/*.min.css'
-    # Do a complete diff in short form as well for good measure. This will
-    # catch changes in excluded files.
-    - git diff --stat --exit-code
-    # Built an entire Drupal site with core, contrib and custom code
-    # First we build Drupal core only. Instead of using the profile specified in
-    # the make  file we use the one we have just build.
-    # This way we do not have to update drupal.make for each build.
-    - drush make drupal.make --projects=drupal -y $DRUPAL_SITE_PATH
-    # Copy the current profile which has just been built into Drupal core
-    - mkdir $DRUPAL_SITE_PATH/profiles/ding2
-    - cp -R ./* $DRUPAL_SITE_PATH/profiles/ding2/
-    # Install the site using the ding2 profile
-    - (cd $DRUPAL_SITE_PATH && drush site-install ding2 --db-url=mysql://ubuntu@127.0.0.1/circle_test -y)
+    - make circle-setup
+    - make circle-run-unit-tests
+
   post:
     # Clean up after site install.
     # sudo is required here. The files are not writeable.
     - sudo rm -rf $DRUPAL_SITE_PATH/sites/default/settings.php $DRUPAL_SITE_PATH/sites/default/files
     # Remove node_modules folder. This is not needed in the final artifact.
     - rm -rf $DRUPAL_SITE_PATH/profiles/ding2/themes/ddbasic/node_modules
+    # Remove ding_test composer vendor folder
+    - rm -rf $DRUPAL_SITE_PATH/profiles/ding2/modules/ding_test/vendor
     # Wrap the site into an archieve and expose it as an artifact.
     - tar -zcvf $CIRCLE_ARTIFACTS/ding2-$CIRCLE_SHA1.tar.gz -C $DRUPAL_SITE_PATH .

--- a/ding2.make
+++ b/ding2.make
@@ -42,10 +42,13 @@ projects[ctools][patch][] = "https://www.drupal.org/files/issues/ctools-readd_ac
 projects[date][subdir] = "contrib"
 projects[date][version] = "2.8"
 
-; Patch to fix empty order_id. See https://drupal.org/node/2107389
 projects[dibs][subdir] = "contrib"
 projects[dibs][version] = "1.0"
+; Patch to fix empty order_id. See https://drupal.org/node/2107389
 projects[dibs][patch][] = "http://drupal.org/files/dibs-2107389-2.patch"
+; Patch make dibs_split_payments payment_transaction_id a NOT NULL database field.
+; https://www.drupal.org/node/2812891
+projects[dibs][patch][] = "https://www.drupal.org/files/issues/mysql_5.7_compatibility-2812891-2.patch"
 
 projects[diff][subdir] = "contrib"
 projects[diff][version] = "3.2"

--- a/ding2.make
+++ b/ding2.make
@@ -222,6 +222,9 @@ projects[menu_position][version] = "1.1"
 
 projects[message][subdir] = "contrib"
 projects[message][version] = "1.10"
+; Patch messages to make message id a NOT NULL database field.
+; https://www.drupal.org/node/2051751
+projects[message][patch][0] = "https://www.drupal.org/files/message-primary_nullable-2051751-7.patch"
 
 projects[metatag][subdir] = "contrib"
 projects[metatag][version] "1.10"

--- a/modules/bpi/bpi.install
+++ b/modules/bpi/bpi.install
@@ -15,6 +15,7 @@ function bpi_schema() {
     'fields' => array(
       'id' => array(
         'type' => 'serial',
+        'not null' => TRUE
       ),
       'nid' => array(
         'type' => 'int',

--- a/modules/ding_test/ding_test.module
+++ b/modules/ding_test/ding_test.module
@@ -1,14 +1,17 @@
 <?php
+/**
+ * @file
+ * Support functionallity for testing.
+ */
+
+use Drupal\xautoload\Adapter\LocalDirectoryAdapter;
 
 /**
  * Implements hook_xautoload().
  *
  * Have xautoload load classes from our vendor-dir.
- *
- * @param \Drupal\xautoload\Adapter\LocalDirectoryAdapter $adapter
- *   An adapter object that can register stuff into the class loader.
  */
-function ding_test_xautoload($adapter) {
+function ding_test_xautoload(LocalDirectoryAdapter $adapter) {
   $adapter->absolute()->composerDir(
     drupal_get_path('module', 'ding_test') . '/vendor/composer'
   );


### PR DESCRIPTION
The CI-setup is needed in bbs-master (which the aleph-provider development happens off) as well.