### PR TITLE
Make it possible to disable ting_fulltext

### DIFF
--- a/ding2.profile
+++ b/ding2.profile
@@ -658,7 +658,11 @@ function ding2_module_list_as_operations($module_list) {
  */
 function ding2_module_enable(&$install_state) {
   $modules = variable_get('ding_module_selected', array());
+  // Modules we dont have an explicit dependency on but still want enabled by
+  // default. If the user later on does not need the module it can be disabled
+  // manually.
   $modules[] = 'l10n_update';
+  $modules[] = 'ting_fulltext';
   $modules[] = 'ting_infomedia';
   $modules[] = 'ding_eresource';
 

--- a/modules/ding_ting_frontend/ding_ting_frontend.info
+++ b/modules/ding_ting_frontend/ding_ting_frontend.info
@@ -20,7 +20,6 @@ dependencies[] = strongarm
 dependencies[] = ting
 dependencies[] = ting_covers
 dependencies[] = ting_field_search
-dependencies[] = ting_fulltext
 dependencies[] = ting_proxy
 dependencies[] = ting_reference
 dependencies[] = ting_relation


### PR DESCRIPTION
For good measure I've done a re-install after the .info dependency was removed, verified that ting_fulltext now no longer was enabled, then added it as a "soft" dependency in ding2.profile, did a re-install and verified that it was now enabled again.

BBS-42