### PR TITLE
 BBS-41: Implement Primo cover provider

### DIFF
--- a/modules/primo/primo.info
+++ b/modules/primo/primo.info
@@ -4,3 +4,4 @@ core = 7.x
 package = Providers
 project = primo
 dependencies[] = ding_provider
+dependencies[] = xautoload

--- a/modules/primo/primo.info
+++ b/modules/primo/primo.info
@@ -1,0 +1,6 @@
+name = Primo
+description = Implementation of Primo API.
+core = 7.x
+package = Providers
+project = primo
+dependencies[] = ding_provider

--- a/modules/primo/primo.module
+++ b/modules/primo/primo.module
@@ -1,0 +1,203 @@
+<?php
+
+/**
+ * @file
+ * Main module file for Primo.
+ */
+
+define('PRIMO_COVERS_DEFAULT_HOSTNAME', 'leitir.is');
+
+/**
+ * Implements hook_ding_provider().
+ */
+function primo_ding_provider() {
+  return array(
+    'title' => 'Primo provider',
+    'settings' => 'primo_settings_form',
+    'provides' => array(
+      // TODO Remove this dummy provider when we implement proper Primo search
+      // We need to provide something to have a settings page.
+      'dummy' => array(
+        'prefix' => 'dummy',
+      ),
+    ),
+  );
+}
+
+/**
+ * Implements hook_menu().
+ */
+function primo_menu() {
+  $items = array();
+
+  // We also provide a cover implementation. Add a shortcut to the settings form
+  // under the cover settings as well.
+  $items['admin/config/ting/covers/primo'] = array(
+    'title' => 'Primo',
+    'description' => 'Configure integration with Primo service.',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('primo_settings_form'),
+    'access arguments' => array('administer site configuration'),
+    'type' => MENU_LOCAL_TASK,
+  );
+
+  return $items;
+}
+
+/**
+ * Setting form for Primo configuration.
+ *
+ * @return []
+ *   A Form API array
+ */
+function primo_settings_form() {
+  $form = array();
+
+  $form['primo'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Primo service settings'),
+    '#tree' => FALSE,
+  );
+
+  $form['primo']['primo_base_url'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Base URL'),
+    '#description' => t('Base URL for Primo service.'),
+    '#required' => TRUE,
+    '#default_value' => variable_get('primo_base_url', ''),
+  );
+
+  $form['primo']['primo_institution_code'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Institution code'),
+    '#description' => t('Relevant for restricted scopes or for when searching against Primo Central.'),
+    '#required' => TRUE,
+    '#default_value' => variable_get('primo_institution_code', ''),
+  );
+
+  $form['primo']['primo_enable_logging'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable logging'),
+    '#default_value' => variable_get('primo_enable_logging', FALSE),
+    '#description' => t('Logs requests to the Primo webservice.'),
+  );
+
+  $form['covers'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Covers'),
+    '#tree' => FALSE,
+  );
+
+  $form['covers']['primo_covers_hostname'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Hostname'),
+    '#description' => t('The hostname for which to include covers.'),
+    '#required' => TRUE,
+    '#default_value' => variable_get('primo_covers_hostname',
+      PRIMO_COVERS_DEFAULT_HOSTNAME
+    ),
+  );
+
+  return system_settings_form($form);
+}
+
+/**
+ * Implements hook_ting_covers().
+ */
+function primo_ting_covers($entities) {
+  $ids = array_map(function(TingEntity $entity) {
+    return $entity->ding_entity_id;
+  }, $entities);
+
+  // Replace entity ids with a set of Primo ids which are known to have covers.
+  // TODO: Remove this once we have proper search integration with Primo.
+  $ids = array(
+    'ICE01_PRIMO_TEST000811009',
+    'ICE01_PRIMO_TEST001027834',
+    'ICE01_PRIMO_TEST000335899',
+  );
+
+  $document = primo_load_by_recordid($ids);
+
+  $thumbnail_urls = array_fill_keys($ids, NULL);
+  array_walk($thumbnail_urls, function(&$url, $id, DOMDocument $document) {
+    $urls = primo_extract_thumbnail_urls($document, $id);
+    // We can only handle a single thumbnail per id so return the first.
+    $url = array_pop($urls);
+  }, $document);
+
+  // Splice the results back into an array mapping original ids with thumbnail
+  // urls for Primo ids.
+  // TODO: Remove this once we have proper search integration with Primo.
+  $thumbnail_urls = array_slice($thumbnail_urls, 0, count($entities));
+  return array_combine(
+    array_keys($entities),
+    array_pad($thumbnail_urls, count($entities), reset($thumbnail_urls))
+  );
+}
+
+/**
+ * Load documents based on their record id.
+ *
+ * @param string[] $rids
+ *   An array of Primo record ids.
+ *
+ * @return \DOMDocument
+ *   A DOMDocument containing the resulting XML. This XML will contain elements
+ *   for each of the requested record ids.
+ */
+function primo_load_by_recordid(array $rids) {
+  $url = variable_get('primo_base_url') . '/PrimoWebServices/xservice/search/brief';
+  $params = array(
+    'institution' => variable_get('primo_institution_code'),
+    'query' => 'rid,contains,' . implode($rids, ' OR '),
+    'indx' => 1,
+    'bulkSize' => count($rids),
+  );
+
+  $result = drupal_http_request(url($url, array('query' => $params)));
+
+  $document = new DOMDocument();
+  $document->loadXML($result->data);
+
+  return $document;
+}
+
+/**
+ * Extract thumbnail urls for a record in an XML document
+ *
+ * @param \DOMDocument $document
+ *   The document containing record information.
+ * @param string $id
+ *   The record id for which to extract the thumbnail url.
+ *
+ * @return string[]
+ *   An array of thumbnail urls for the record.
+ */
+function primo_extract_thumbnail_urls(DOMDocument $document, $id) {
+  $xpath = new DOMXPath($document);
+  $xpath->registerNamespace(
+    's', 'http://www.exlibrisgroup.com/xsd/jaguar/search');
+  $xpath->registerNamespace(
+    'p', 'http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib');
+  $thumbnail_elements = $xpath->query('//s:DOC[.//p:recordid[.="' . $id .  '"]]//s:thumbnail'
+  );
+
+  $thumbnail_urls = [];
+  foreach ($thumbnail_elements as $thumbnail_element) {
+    $thumbnail_urls[] = $thumbnail_element->nodeValue;
+  }
+
+  // Primo results are known to include duplicates. Remove these.
+  $thumbnail_urls = array_unique($thumbnail_urls);
+
+  $thumbnail_urls = array_filter($thumbnail_urls, function ($url) {
+    // Only return thumbnail urls from an approved host. Primo also contains
+    // thumbnail urls for Google Books an potentially other sources. We do not
+    // want to include those here.
+    $hostname = variable_get('primo_covers_hostname', PRIMO_COVERS_DEFAULT_HOSTNAME);
+    return parse_url($url, PHP_URL_HOST) == $hostname;
+  });
+
+  return $thumbnail_urls;
+}

--- a/modules/primo/primo.module
+++ b/modules/primo/primo.module
@@ -5,6 +5,9 @@
  * Main module file for Primo.
  */
 
+use Drupal\xautoload\Adapter\LocalDirectoryAdapter;
+use Primo\Exception\TransferException;
+
 define('PRIMO_COVERS_DEFAULT_HOSTNAME', 'leitir.is');
 
 /**
@@ -105,6 +108,9 @@ function primo_settings_form() {
  * Implements hook_ting_covers().
  */
 function primo_ting_covers($entities) {
+  // A map from entity ids to urls for corresponding covers.
+  $covers = array();
+
   $ids = array_map(function(TingEntity $entity) {
     return $entity->ding_entity_id;
   }, $entities);
@@ -117,23 +123,35 @@ function primo_ting_covers($entities) {
     'ICE01_PRIMO_TEST000335899',
   );
 
-  $document = primo_load_by_recordid($ids);
+  try {
+    $document = primo_load_by_recordid($ids);
 
-  $thumbnail_urls = array_fill_keys($ids, NULL);
-  array_walk($thumbnail_urls, function(&$url, $id, DOMDocument $document) {
-    $urls = primo_extract_thumbnail_urls($document, $id);
-    // We can only handle a single thumbnail per id so return the first.
-    $url = array_pop($urls);
-  }, $document);
+    $thumbnail_urls = array_fill_keys($ids, NULL);
+    array_walk(
+      $thumbnail_urls,
+      function (&$url, $id, DOMDocument $document) {
+        $urls = primo_extract_thumbnail_urls($document, $id);
+        // We can only handle a single thumbnail per id so return the first.
+        $url = array_pop($urls);
+      },
+      $document
+    );
 
-  // Splice the results back into an array mapping original ids with thumbnail
-  // urls for Primo ids.
-  // TODO: Remove this once we have proper search integration with Primo.
-  $thumbnail_urls = array_slice($thumbnail_urls, 0, count($entities));
-  return array_combine(
-    array_keys($entities),
-    array_pad($thumbnail_urls, count($entities), reset($thumbnail_urls))
-  );
+    // Splice the results back into an array mapping original ids with thumbnail
+    // urls for Primo ids.
+    // TODO: Remove this once we have proper search integration with Primo.
+    $thumbnail_urls = array_slice($thumbnail_urls, 0, count($entities));
+    $covers = array_combine(
+      array_keys($entities),
+      array_pad($thumbnail_urls, count($entities), reset($thumbnail_urls))
+    );
+  }
+  catch (TransferException $e) {
+    // Do nothing. If an exception occurs then we simply to not return any
+    // covers from Primo.
+  }
+
+  return $covers;
 }
 
 /**
@@ -145,6 +163,9 @@ function primo_ting_covers($entities) {
  * @return \DOMDocument
  *   A DOMDocument containing the resulting XML. This XML will contain elements
  *   for each of the requested record ids.
+ *
+ * @throws \Primo\Exception\TransferException
+ *   Thrown if an error occurs when retrieveing data from Primo.
  */
 function primo_load_by_recordid(array $rids) {
   $url = variable_get('primo_base_url') . '/PrimoWebServices/xservice/search/brief';
@@ -155,7 +176,22 @@ function primo_load_by_recordid(array $rids) {
     'bulkSize' => count($rids),
   );
 
-  $result = drupal_http_request(url($url, array('query' => $params)));
+  $request_url = url($url, array('query' => $params));
+  $result = drupal_http_request($request_url);
+
+  if (!empty($result->error)) {
+    watchdog('primo',
+      'Unable to retrieve records %ids from %url: (%code) %error',
+      array(
+        '%ids' => implode(',', $rids),
+        '%url' => $request_url,
+        '%code' => $result->code,
+        '%error' => $result->error,
+      ),
+      WATCHDOG_WARNING
+    );
+    throw new TransferException($result->error, $result->code);
+  }
 
   $document = new DOMDocument();
   $document->loadXML($result->data);
@@ -200,4 +236,14 @@ function primo_extract_thumbnail_urls(DOMDocument $document, $id) {
   });
 
   return $thumbnail_urls;
+}
+
+/**
+ * Implements hook_xautoload().
+ */
+function primo_xautoload(LocalDirectoryAdapter $adapter) {
+  $adapter->addPsr4(
+    'Primo',
+    'src/Primo'
+  );
 }

--- a/modules/primo/src/Primo/Exception/TransferException.php
+++ b/modules/primo/src/Primo/Exception/TransferException.php
@@ -1,0 +1,11 @@
+<?php
+
+
+namespace Primo\Exception;
+
+/**
+ * Exception which represents errors in the communication with Primo
+ */
+class TransferException extends \Exception {
+
+}


### PR DESCRIPTION
This is an initial implementation of cover retrieval for Primo.

This includes:
- Basic plumbing for the Primo module and provider setup
- Forms for configuring the Primo integration
- Functionality for retrieving covers from Primo for Ting entities.

This comes with a couple of caveats:
- This is the first stab at implementing Primo integration. It is quite
narrowly focused at the moment. It should be refactored once we begin
implementing Primo search and have a better client library.
- As we do not have actual search results from Primo we fake a set of
known Primo ids which we know will return covers.
- Our development setup currently fails when trying to download covers
from leitir.is. This is probably an issue with https handling. This
needs to be investigated further.

![ding provider ding2 docker 2017-10-18 11-23-59](https://user-images.githubusercontent.com/73966/31710953-dac1035e-b3f6-11e7-833e-b8d95b34fb14.png)
