### PR TITLE
BBS-126 - Refactor Field/filters and BooleanStatementGroup

### DIFF
--- a/modules/p2/ding_entity_rating/ding_entity_rating.serendipity.inc
+++ b/modules/p2/ding_entity_rating/ding_entity_rating.serendipity.inc
@@ -5,6 +5,8 @@
  * This module provides serendipity functions based on user lists and loans.
  */
 
+use Ting\Search\BooleanStatementGroup;
+use Ting\Search\BooleanStatementInterface;
 use Ting\Search\TingSearchCommonFields;
 use Ting\Search\TingSearchFieldFilter;
 
@@ -54,22 +56,22 @@ function ding_entity_rating_materials_by_rating_serendipity_add(array $context) 
     $facets = array();
 
     $field_filters = [];
-    // Extract subjects.
+    // Extract subjects, add them as filters.
     $subject = $ting_object->getSubjects();
     foreach ($subject as & $facet) {
-      $field_filters[] = new TingSearchFieldFilter(TingSearchCommonFields::SUBJECT, $facet, TingSearchFieldFilter::OP_OR);
+      $field_filters[] = new TingSearchFieldFilter(TingSearchCommonFields::SUBJECT, $facet);
     }
 
-    // Build author array.
+    // Build author array, add them as filters.
     if (count($facets) == 0) {
       $authors = $ting_object->getCreators();
       foreach ($authors as $author) {
-        $field_filters[] = new TingSearchFieldFilter(TingSearchCommonFields::AUTHOR, $author, TingSearchFieldFilter::OP_OR);
+        $field_filters[] = new TingSearchFieldFilter(TingSearchCommonFields::AUTHOR, $author);
       }
     }
 
-    // Search with only subjects.
-    $query = ting_start_query()->addFieldFilters($field_filters);
+    // Perform a search for materials with any of the subjects or authors.
+    $query = ting_start_query()->addFieldFilters($field_filters, BooleanStatementInterface::OP_OR);
 
     if (empty($query)) {
       return array();

--- a/modules/p2/ding_serendipity/ding_serendipity.module
+++ b/modules/p2/ding_serendipity/ding_serendipity.module
@@ -386,8 +386,9 @@ function ding_serendipity_validate_materials(array $keys) {
   // Also add the audience to the query, if the user has a clear audience.
   $audience = ding_serendipity_user_audience();
   if ($audience !== FALSE) {
-    $query->addFieldFilters(new TingSearchFieldFilter(TingSearchCommonFields::CATEGORY, $audience));
+    $query->addFieldFilter(TingSearchCommonFields::CATEGORY, $audience);
   }
+  $result = [];
   try {
     $result = ding_serendipity_do_search($query, array('limit' => count($keys)));
   }

--- a/modules/p2/ding_serendipity_lists/ding_serendipity_lists.module
+++ b/modules/p2/ding_serendipity_lists/ding_serendipity_lists.module
@@ -362,7 +362,7 @@ function ding_serendipity_lists_author_from_lists_serendipity_add($context) {
 
     $field_filters = [];
     // Pick the first author.
-    $field_filters[] = new TingSearchFieldFilter(TingSearchCommonFields::AUTHOR, $author[0], TingSearchFieldFilter::OP_AND);
+    $field_filters[] = new TingSearchFieldFilter(TingSearchCommonFields::AUTHOR, $author[0]);
 
     // Taxonomy term pages (except frontpage) has a subject we want to add to
     // the CQL.
@@ -374,14 +374,14 @@ function ding_serendipity_lists_author_from_lists_serendipity_add($context) {
 
       // Fallback to dc.subject.
       if ($value === FALSE) {
-        $field_filters[] = new TingSearchFieldFilter(TingSearchCommonFields::SUBJECT, $term->name, TingSearchFieldFilter::OP_AND);
+        $field_filters[] = new TingSearchFieldFilter(TingSearchCommonFields::SUBJECT, $term->name);
       }
     }
 
     // Limit to same language to reduce signal to noise.
     $lang = $ting_entity->getLanguage();
     if (!empty($lang) && $lang !== "Flere sprog") {
-      $field_filters[] = new TingSearchFieldFilter(TingSearchCommonFields::LANGUAGE, $ting_entity->getLanguage(), TingSearchFieldFilter::OP_AND);
+      $field_filters[] = new TingSearchFieldFilter(TingSearchCommonFields::LANGUAGE, $ting_entity->getLanguage());
     }
     $query = ting_start_query()->addFieldFilters($field_filters);
 

--- a/modules/p2/ding_serendipity_taxonomy_term/ding_serendipity_taxonomy_term.module
+++ b/modules/p2/ding_serendipity_taxonomy_term/ding_serendipity_taxonomy_term.module
@@ -104,7 +104,10 @@ function _ding_serendipity_taxonomy_term_query_from_term(array $term_array) {
   }
   else {
     // Just add the term name itself as a boolean field.
-    $query->addFieldFilters(new TingSearchFieldFilter($term_array['term']->name));
+    // TODO BBS-SAL: How will searching directly on a term be supported by
+    // Primo? Chould this actually be a common field which should then just be
+    // rendered as a boolean field?
+    $query->addFieldFilters($term_array['term']->name);
   }
 
   return $query;

--- a/modules/p2/ding_serendipity_ting_entity/ding_serendipity_ting_entity.module
+++ b/modules/p2/ding_serendipity_ting_entity/ding_serendipity_ting_entity.module
@@ -10,6 +10,7 @@
  *  via ADHL or ADHR.
  */
 
+use Ting\Search\BooleanStatementGroup;
 use Ting\Search\BooleanStatementInterface;
 use Ting\Search\TingSearchCommonFields;
 use Ting\Search\TingSearchFieldFilter;
@@ -108,16 +109,15 @@ function ding_serendipity_ting_entity_ting_object_author_serendipity_add($contex
   }
 
   // Find related content from any of the authors.
-  $field_filters = [];
-  foreach ($creators as $creator) {
-    $field_filters[] = new TingSearchFieldFilter(TingSearchCommonFields::AUTHOR, $creator, '=', BooleanStatementInterface::OP_OR);
-  }
-  $query = ting_start_query()->addFieldFilters($field_filters);
+  $field_filters = array_map(function($creator) {
+    return new TingSearchFieldFilter(TingSearchCommonFields::AUTHOR, $creator);
+  }, $creators);
+  $query = ting_start_query()->addFieldFilters($field_filters, BooleanStatementInterface::OP_OR);
 
   // Limit to same language to reduce signal to noise.
   $lang = $obj->getLanguage();
   if (!empty($lang) && $lang !== "Flere sprog") {
-    $query->addFieldFilters(new TingSearchFieldFilter(TingSearchCommonFields::LANGUAGE, $lang));
+    $query->addFieldFilter(TingSearchCommonFields::LANGUAGE, $lang);
   }
 
   $results = ding_serendipity_do_search($query);
@@ -154,10 +154,10 @@ function ding_serendipity_ting_entity_ting_object_subject_serendipity_add($conte
 
   // Find related content from any of the subjects.
   $field_filters = array_map(function($subject) {
-    return new TingSearchFieldFilter(TingSearchCommonFields::SUBJECT, $subject, '=', BooleanStatementInterface::OP_OR);
+    return new TingSearchFieldFilter(TingSearchCommonFields::SUBJECT, $subject, '=');
   }, $subjects);
 
-  $query = ting_start_query()->addFieldFilters($field_filters);
+  $query = ting_start_query()->addFieldFilters($field_filters, BooleanStatementInterface::OP_OR);
   $results = ding_serendipity_do_search($query);
   ding_serendipity_exclude($results, $context['ting_object_id']);
 
@@ -196,7 +196,7 @@ function ding_serendipity_ting_entity_ting_object_type_serendipity_add($context)
 
   if ($type) {
     // Find related content that matches the type.
-    $query = ting_start_query()->addFieldFilters(new TingSearchFieldFilter(TingSearchCommonFields::MATERIAL_TYPE, $type));
+    $query = ting_start_query()->addFieldFilter(TingSearchCommonFields::MATERIAL_TYPE, $type);
     $results = ding_serendipity_do_search($query);
     ding_serendipity_exclude($results, $context['ting_object_id']);
 

--- a/modules/ting/src/Search/BooleanStatementGroup.php
+++ b/modules/ting/src/Search/BooleanStatementGroup.php
@@ -1,6 +1,12 @@
 <?php
 /**
- * The BooleanStatementGroup class.
+ * @file
+ * The BooleanStatementGroup class
+ */
+
+/**
+ * Groups one or more boolean statements together. The statements are joined by
+ * a boolean operator.
  */
 namespace Ting\Search;
 
@@ -16,7 +22,7 @@ class BooleanStatementGroup implements BooleanStatementInterface {
   /**
    * The grouped statements.
    *
-   * @var \Ting\Search\BooleanStatementInterface[]
+   * @var mixed[]
    */
   protected $statements = [];
 
@@ -27,16 +33,20 @@ class BooleanStatementGroup implements BooleanStatementInterface {
   protected $logicOperator;
 
   /**
-   * BooleanStatementGroup constructor.
+   * Construct a BooleanStatementGroup.
    *
-   * @param \Ting\Search\TingSearchFieldFilter[] $statements
-   *   The grouped statements
+   * The statements is one or more groups or fields and will be joined together
+   * in a single group via the $logic_operator operator.
    *
-   * @param string                               $logic_operator
+   * @param mixed[] $statements
+   *   Instances of \Ting\Search\BooleanStatementGroup and
+   *   \Ting\Search\TingSearchFieldFilter
+   *
+   * @param string $logic_operator
    *   A TingSearchBooleanStatementInterface::OP_* operation.
    */
   public function __construct(array $statements, $logic_operator = BooleanStatementInterface::OP_AND) {
-    $this->statements = $statements;
+    $this->add($statements);
     $this->logicOperator = $logic_operator;
   }
 
@@ -48,10 +58,21 @@ class BooleanStatementGroup implements BooleanStatementInterface {
   }
 
   /**
+   * Set the logic-operator used to join the members of the group.
+   *
+   * @param string $logic_operator
+   *   A TingSearchBooleanStatementInterface::OP_* operation.
+   */
+  public function setLogicOperator($logic_operator) {
+    $this->logicOperator = $logic_operator;
+  }
+
+  /**
    * The grouped statements.
    *
-   * @return \Ting\Search\BooleanStatementInterface[]
-   *   The statements.
+   * @return mixed[]
+   *   The statements, instances of BooleanStatementGroup and
+   *   TingSearchFieldFilter.
    */
   public function getStatements() {
     return $this->statements;
@@ -60,10 +81,23 @@ class BooleanStatementGroup implements BooleanStatementInterface {
   /**
    * Add a statement to the group.
    *
-   * @param \Ting\Search\BooleanStatementInterface $statement
-   *   The statement.
+   * @param mixed[] $statements
+   *   One or more implementations of \Ting\Search\BooleanStatementGroup and
+   *   \Ting\Search\TingSearchFieldFilter.
    */
-  public function add(BooleanStatementInterface $statement) {
-    $this->statements[] = $statement;
+  public function add($statements) {
+    if (!is_array($statements)) {
+      $statements = [$statements];
+    }
+    foreach ($statements as $statement) {
+      if ($statement instanceof self || $statement instanceof TingSearchFieldFilter) {
+        $this->statements[] = $statement;
+      }
+      else {
+        throw new \InvalidArgumentException(
+          "Unsupported type, only BooleanStatementInterface and TingSearchFieldFilter is supported"
+        );
+      }
+    }
   }
 }

--- a/modules/ting/src/Search/StatementGroupRender.php
+++ b/modules/ting/src/Search/StatementGroupRender.php
@@ -50,6 +50,8 @@ class StatementGroupRender {
    *
    * @param \Ting\Search\BooleanStatementInterface[] $statements
    *   The list of statements to render.
+   * @param string $logic_operator
+   *   A TingSearchBooleanStatementInterface::OP_* operation.
    *
    * @return string
    *   The rendered group, empty string if the group is empty.
@@ -57,8 +59,8 @@ class StatementGroupRender {
    * @throws \Exception
    *   In case the group contains invalid members.
    */
-  public function renderStatements($statements) {
-    return $this->renderGroup(new BooleanStatementGroup($statements));
+  public function renderStatements($statements, $logic_operator = BooleanStatementInterface::OP_AND) {
+    return $this->renderGroup(new BooleanStatementGroup($statements, $logic_operator));
   }
 
   /**
@@ -102,7 +104,7 @@ class StatementGroupRender {
       // Add joining logic operator if we're not at the first element.
       if ($statement_index > 0) {
         // TODO: This could be an enum.
-        $rendered_statement .= ' ' . $statement->getLogicOperator() . ' ';
+        $rendered_statement .= ' ' . $group->getLogicOperator() . ' ';
       }
 
       // We're at another group, recurse.

--- a/modules/ting/src/Search/TingSearchFieldFilter.php
+++ b/modules/ting/src/Search/TingSearchFieldFilter.php
@@ -14,7 +14,7 @@ namespace Ting\Search;
  *
  * @package Ting\Search
  */
-class TingSearchFieldFilter implements BooleanStatementInterface {
+class TingSearchFieldFilter {
 
   const BOOLEAN_FIELD_VALUE = self::class . '-MISSING-VALUE';
 
@@ -41,17 +41,6 @@ class TingSearchFieldFilter implements BooleanStatementInterface {
    */
   protected $value;
 
-
-  /**
-   * The logic operator used to evaluate the field evaluation against the
-   * previous statement.
-   *
-   * @see BooleanStatementInterface::OP_*
-   *
-   * @var string
-   */
-  protected $logicOperator;
-
   /**
    * TingSearchFieldFilter constructor.
    *
@@ -61,31 +50,19 @@ class TingSearchFieldFilter implements BooleanStatementInterface {
    *   The field name.
    *
    * @param mixed|TingSearchFieldFilter::BOOLEAN_FIELD_VALUE $value
-   *   Field value, if omitted or set to TingSearchFieldFilter::BOOLEAN_FIELD_VALUE
-   *   the field is treated as a boolean field that will be compared without an
-   *   operator Eg:
+   *   Field value, if omitted or set to
+   *   TingSearchFieldFilter::BOOLEAN_FIELD_VALUE the field is treated as a
+   *   boolean field that will be compared without an operator Eg:
    *   (myboolfield AND anotherfield=123)
-   *
    * @param string $operator
    *   Operator to use when comparing the field instance with a value.
-   *
-   * @param string $logic_operator
-   *   Operator to use when comparing the evaluated field with a previous
-   *   statement.
    */
-  public function __construct($name, $value = self::BOOLEAN_FIELD_VALUE, $operator = '=', $logic_operator = BooleanStatementInterface::OP_AND) {
+  public function __construct($name, $value = self::BOOLEAN_FIELD_VALUE, $operator = '=') {
     $this->name = $name;
     $this->operator = $operator;
-    $this->logicOperator = $logic_operator;
     $this->value = $value;
   }
 
-  /**
-   * {@inheritdoc}
-   */
-  public function getLogicOperator() {
-    return $this->logicOperator;
-  }
 
   /**
    * Returns the name of the field.

--- a/modules/ting_search/tests/ting_search_unit.test
+++ b/modules/ting_search/tests/ting_search_unit.test
@@ -7,6 +7,7 @@ use Ting\Search\BooleanStatementInterface;
 use Ting\Search\StatementGroupRender;
 use Ting\Search\TingSearchCommonFields;
 use Ting\Search\TingSearchFieldFilter;
+use Ting\Search\TingSearchRequest;
 use Ting\Search\TingSearchStrategyInterface;
 
 class DingSearchUnitTest extends DingUnitTestBase {
@@ -51,30 +52,37 @@ class DingSearchUnitTest extends DingUnitTestBase {
   public function testStatementGroupRenderer() {
     // The final query-string the arrangement of groupings and fields below
     // should end up as. Notice that we use mapped fields.
-    $expected_result = '(test_author="1" AND test_subject="1") OR test_category="1\"" OR (test_language OR test_author="1" AND (test_subject="1" OR test_category="1"))';
+    $expected_result = '(test_author<"1" AND test_subject>"2") OR test_category="3\"" OR ((test_language OR test_author="5") AND (test_subject="6" OR test_category="7"))';
 
     // Build the query, use the common names that will have to be mapped in
     // order to match the expected output.
+    // Setup an "AND" group.
     $group1 = new BooleanStatementGroup([
-      new TingSearchFieldFilter(TingSearchCommonFields::AUTHOR, 1),
-      new TingSearchFieldFilter(TingSearchCommonFields::SUBJECT, 1, '=', BooleanStatementInterface::OP_AND),
-    ]);
-
-    $group2 = new TingSearchFieldFilter(TingSearchCommonFields::CATEGORY, '1"', '=', BooleanStatementInterface::OP_OR);
-
-    // Group 4 is nested inside group 3 so we define it first.
-    $group4 = new BooleanStatementGroup([
-      new TingSearchFieldFilter(TingSearchCommonFields::SUBJECT, 1),
-      new TingSearchFieldFilter(TingSearchCommonFields::CATEGORY, 1, '=', BooleanStatementInterface::OP_OR),
+      new TingSearchFieldFilter(TingSearchCommonFields::AUTHOR, 1, '<'),
+      new TingSearchFieldFilter(TingSearchCommonFields::SUBJECT, 2, '>'),
     ], BooleanStatementInterface::OP_AND);
 
-    $group3 = new BooleanStatementGroup([
-      // Test boolean field behaviour (that is: this field should be rendered without the comparison).
+    // Standalone field.
+    $field2 = new TingSearchFieldFilter(TingSearchCommonFields::CATEGORY, '3"');
+
+    // Group 4 (an OR group) is nested inside group 3 so we define it first.
+    $group4 = new BooleanStatementGroup([
+      // Test boolean field behaviour (that is: this field should be rendered
+      // without the comparison).
       new TingSearchFieldFilter(TingSearchCommonFields::LANGUAGE),
-      new TingSearchFieldFilter(TingSearchCommonFields::AUTHOR, 1, '=', BooleanStatementInterface::OP_OR),
-      $group4
+      new TingSearchFieldFilter(TingSearchCommonFields::AUTHOR, 5)
     ], BooleanStatementInterface::OP_OR);
-    $groups = [$group1, $group2, $group3];
+
+    // Group 5 (an AND group) is nested inside group 3 so we define it first.
+    $group5 = new BooleanStatementGroup([
+      new TingSearchFieldFilter(TingSearchCommonFields::SUBJECT, 6),
+      new TingSearchFieldFilter(TingSearchCommonFields::CATEGORY, 7),
+    ], BooleanStatementInterface::OP_OR);
+
+    // Join group 4 and 5 together with an AND group.
+    $group3 = new BooleanStatementGroup([$group4, $group5], BooleanStatementInterface::OP_AND);
+
+    $groups = [$group1, $field2, $group3];
 
     // Setup a renderer configured to use our own mapping of fields.
     $strategy_double = $this->prophet->prophesize(TingSearchStrategyInterface::class);
@@ -90,11 +98,68 @@ class DingSearchUnitTest extends DingUnitTestBase {
     $renderer = new StatementGroupRender($strategy);
 
     // Test that adding a single group around a list does not affect redering.
-    $filter_string_wrapped = $renderer->renderGroup((new BooleanStatementGroup($groups)));
-    $filter_string_from_list = $renderer->renderStatements($groups);
+    $filter_string_wrapped = $renderer->renderGroup((new BooleanStatementGroup($groups, BooleanStatementInterface::OP_OR)));
+    $filter_string_from_list = $renderer->renderStatements($groups, BooleanStatementInterface::OP_OR);
     $this->assertEqual($filter_string_from_list, $filter_string_wrapped, "List of filters is rendered the same way as a list wrapped in a group.");
 
     // Test that the query ends up as we expect.
     $this->assertEqual($expected_result, $filter_string_wrapped);
+  }
+
+  /**
+   * Test that we can add filters to a search request as expected.
+   *
+   * @throws \Exception
+   */
+  public function testTingSearchRequestFilters() {
+    // Setup a search request with a dummy strategy that will never be used as
+    // we don't actually perform any searches.
+    $strategy_double = $this->prophet->prophesize(TingSearchStrategyInterface::class);
+    $strategy = $strategy_double->reveal();
+
+    $query = new TingSearchRequest($strategy);
+
+    // We want to test the following features of the filter-functionality of
+    // TingSearchRequest.
+    // 1) We can add a list of filters and have them wrapped in a group
+    // 2) We can add a single filter and have it wrapped in a group
+    // 3) We can construct our own group and have it added without wrapping
+    // 4) We can use a short-hand function of adding a field and it should
+    // result in the same as 2).
+    $_1_filter_list = [
+      new TingSearchFieldFilter('field1', 'value'),
+      new TingSearchFieldFilter('field1', 'value'),
+    ];
+    $_2_single_filter = new TingSearchFieldFilter('field2', 'value');
+    $_3_filter_group = new BooleanStatementGroup([
+      new TingSearchFieldFilter('field3', 'value'),
+      new TingSearchFieldFilter('field3', 'value'),
+    ], BooleanStatementInterface::OP_OR);
+
+
+    $query->addFieldFilters($_1_filter_list);
+    $query->addFieldFilters($_2_single_filter);
+    $query->addFieldFilters($_3_filter_group);
+    // Use the shorthand for testing 4). This is basically a shorthand for 2)
+    // so we use the same field-name to be able to test it in a moment.
+    $query->addFieldFilter('field2', 'value');
+
+    // This should have added four boolean statement groups.
+    $resulting_filters = $query->getFieldFilters();
+    $this->assertTrue((count($resulting_filters) == 4));
+    $this->assertTrue($resulting_filters[0] instanceof BooleanStatementGroup, 'Filter group 1 is a BooleanStatementGroup');
+    $this->assertTrue($resulting_filters[1] instanceof BooleanStatementGroup, 'Filter group 2 is a BooleanStatementGroup');
+    $this->assertTrue($resulting_filters[2] instanceof BooleanStatementGroup, 'Filter group 3 is a BooleanStatementGroup');
+    $this->assertTrue($resulting_filters[3] instanceof BooleanStatementGroup, 'Filter group 4 is a BooleanStatementGroup');
+
+    // The first two groups should have our first two filterlists in them.
+    $this->assertEqual($resulting_filters[0]->getStatements(), $_1_filter_list, 'Filter group 1 is the expected list');
+    $this->assertEqual($resulting_filters[1]->getStatements()[0], $_2_single_filter, 'Filter group 2 is a single filter');
+
+    // The third should be our previously added boolean group.
+    $this->assertEqual($resulting_filters[2], $_3_filter_group, 'Filter group 3 is the original group');
+
+    // The fourth group should be the same as 2).
+    $this->assertEqual($resulting_filters[3]->getStatements()[0], $_2_single_filter, 'FieldFilter shorthand should be the same as adding a TingSearchFieldFilter manually');
   }
 }


### PR DESCRIPTION
Refactor to remove the boolean operator from the Field Filter and keep it to the group. Having the
operator on the field was confusing as it only applied to the field coming
before the field in question which made the code hard to read.

Instead we now require the developer to use a group if control over the boolean
operator is needed, in all other cases we AND things together

BBS-126