### PR TITLE
Don’t show payments in debt overview.

### DIFF
--- a/modules/aleph/includes/aleph.availability.inc
+++ b/modules/aleph/includes/aleph.availability.inc
@@ -4,7 +4,7 @@
  * Handles availability information from the library system.
  */
 
-use Drupal\aleph\Aleph\AlephMaterial;
+use Drupal\aleph\Aleph\Entity\AlephMaterial;
 use Drupal\aleph\Aleph\Handler\AlephMaterialHandler;
 
 /**

--- a/modules/aleph/src/Aleph/Entity/AlephDebt.php
+++ b/modules/aleph/src/Aleph/Entity/AlephDebt.php
@@ -168,7 +168,9 @@ class AlephDebt {
       $debt->setDebtMaterial(AlephDebtMaterial::createDebtMaterial($debt_xml));
 
       // Add the debt to the debts array.
-      $debts[] = $debt;
+      if ($debt->getType() !== 'Payment') {
+        $debts[] = $debt;
+      }
     }
 
     return $debts;

--- a/modules/aleph/tests/AlephMaterialUnit.test
+++ b/modules/aleph/tests/AlephMaterialUnit.test
@@ -5,7 +5,7 @@
  * Contains the Aleph Material specific unit tests.
  */
 
-use Drupal\aleph\Aleph\AlephMaterial;
+use Drupal\aleph\Aleph\Entity\AlephMaterial;
 use Drupal\ding_test\DingUnitTestBase;
 
 /**


### PR DESCRIPTION
Payments was shown on the 'debts overview'.