### PR TITLE
BBS-41: Remove existing cover information when custom covers are added

### DIFF
--- a/modules/ting_covers/ting_covers.module
+++ b/modules/ting_covers/ting_covers.module
@@ -192,6 +192,27 @@ function ting_covers_get(array $requested_covers) {
 }
 
 /**
+ * Remove all cover information about one or more ting entites.
+ *
+ * @param string|string[] $ids
+ *   One or more ting entity ids.
+ */
+function ting_covers_clean($ids) {
+  if (!is_array($ids)) {
+    $ids = array($ids);
+  }
+
+  array_walk($ids, function($id) {
+    $path = ting_covers_object_path($id);
+    // Delete current file and derivatives if any.
+    file_unmanaged_delete($path);
+    image_path_flush($path);
+    // Delete cache information about the cover not being available.
+    cache_clear_all(_ting_covers_cid($id), 'cache');
+  });
+}
+
+/**
  * Generate a cache id for a ting entity id.
  *
  * @param string $id

--- a/modules/ting_covers/ting_covers.module
+++ b/modules/ting_covers/ting_covers.module
@@ -157,7 +157,7 @@ function ting_covers_get(array $requested_covers) {
     }
 
     // Determine if the local id is a known negative.
-    if (cache_get('ting_covers:' . $id, FALSE)) {
+    if (cache_get(_ting_covers_cid($id), FALSE)) {
       continue;
     }
 
@@ -185,10 +185,23 @@ function ting_covers_get(array $requested_covers) {
 
   // Mark all remaining as not found in cache.
   foreach ($entities as $id => $entity) {
-    cache_set('ting_covers:' . $id, 1, 'cache', $_SERVER['REQUEST_TIME'] + TING_COVERS_DEFAULT_CACHE_LIFETIME);
+    cache_set(ting_covers_cid($id), 1, 'cache', $_SERVER['REQUEST_TIME'] + TING_COVERS_DEFAULT_CACHE_LIFETIME);
   }
 
   return $covers;
+}
+
+/**
+ * Generate a cache id for a ting entity id.
+ *
+ * @param string $id
+ *   The ting entity id.
+ * 
+ * @return string
+ *   A cache id for the cover of the entity.
+ */
+function _ting_covers_cid($id) {
+  return 'ting_covers:' . $id;
 }
 
 /**

--- a/modules/ting_covers_custom/ting_covers_custom.module
+++ b/modules/ting_covers_custom/ting_covers_custom.module
@@ -74,6 +74,53 @@ function ting_covers_custom_menu_local_tasks_alter(&$data, $router_item, $root_p
 }
 
 /**
+ * Implements hook_entity_insert().
+ */
+function ting_covers_custom_entity_insert($entity, $type) {
+  if ($type === 'relation' && $entity->relation_type === 'ting_covers_custom_cover') {
+    // Remove existing cover information when uploading a new cover.
+    ting_covers_custom_reset_relation_cover($entity);
+  }
+}
+
+/**
+ * Implements hook_entity_update().
+ */
+function ting_covers_custom_entity_update($entity, $type) {
+  if ($type === 'relation' && $entity->relation_type === 'ting_covers_custom_cover') {
+    // Remove existing cover information when uploading a new cover.
+    ting_covers_custom_reset_relation_cover($entity);
+  }
+}
+
+/**
+ * Implements hook_entity_update().
+ */
+function ting_covers_custom_entity_delete($entity, $type) {
+  // Remove all cover information when deleting a cover.
+  if ($type === 'relation' && $entity->relation_type === 'ting_covers_custom_cover') {
+    ting_covers_custom_reset_relation_cover($entity);
+  }
+}
+
+/**
+ * Reset cover information for Ting entities that a custom cover relates to.
+ *
+ * We want to make sure that new cover information is propagated to the frontend
+ * as quickly as possible.
+ *
+ * @param object $relation
+ *   The relation between a Ting entity and a custom cover entity.
+ */
+function ting_covers_custom_reset_relation_cover($relation) {
+  $endpoints = relation_get_endpoints($relation, 'ting_object');
+  $ids = array_map(function(\TingEntity $entity) {
+    return $entity->getId();
+  }, $endpoints['ting_object']);
+  ting_covers_clean($ids);
+}
+
+/**
  * Implements hook_module_implements_alter().
  */
 function ting_covers_custom_module_implements_alter(&$implementations, $hook) {


### PR DESCRIPTION
Ting covers contain multiple layers of caching to be performant:

- Image urls refer directly to image style derivatives. If these exist they are returned immediately.
- If not they are generated from the source using image presets.
- If there are no covers for an entity this information is cached as well to prevent checks every time the image is accessed.

This PR removes all of these levels when a custom cover is modified.