### PR TITLE
BBS-140: Load materials from Primo

### DIFF
--- a/ding2.make
+++ b/ding2.make
@@ -53,6 +53,12 @@ projects[dibs][patch][] = "https://www.drupal.org/files/issues/mysql_5.7_compati
 projects[diff][subdir] = "contrib"
 projects[diff][version] = "3.2"
 
+projects[drupal_psr3][subdir] = "contrib"
+projects[drupal_psr3][version] = "1.1"
+; Replace Composer with XAutoload
+; https://www.drupal.org/node/2921242
+projects[drupal_psr3][patch][] = "https://www.drupal.org/files/issues/drupal_psr3-optional_autoloading-2921242-2.patch"
+
 ; The patch ensures that file upload patch is created on file upload. It normally
 ; created on settings form save, but as we use feature this do not work.
 ; See https://www.drupal.org/node/2410241
@@ -454,6 +460,11 @@ libraries[guzzle][download][url] = "https://github.com/guzzle/guzzle.git"
 libraries[guzzle][download][tag] = "6.2.2"
 libraries[guzzle][destination] = "libraries"
 
+libraries[guzzle-log-middleware][download][type] = "git"
+libraries[guzzle-log-middleware][download][url] = "https://github.com/rtheunissen/guzzle-log-middleware"
+libraries[guzzle-log-middleware][download][tag] = "v0.4.0"
+libraries[guzzle][destination] = "libraries"
+
 libraries[http-message][download][type] = "git"
 libraries[http-message][download][url] = "https://github.com/php-fig/http-message.git"
 libraries[http-message][download][tag] = "1.0.1"
@@ -468,6 +479,11 @@ libraries[leaflet][download][type] = "get"
 libraries[leaflet][download][url] = "http://cdn.leafletjs.com/downloads/leaflet-0.7.3.zip"
 libraries[leaflet][directory_name] = "leaflet"
 libraries[leaflet][destination] = "libraries"
+
+libraries[log][download][type] = "git"
+libraries[log][download][url] = "https://github.com/php-fig/log"
+libraries[log][download][tag] = "1.0.2"
+libraries[log][destination] = "libraries"
 
 libraries[phly-http][download][type] = "git"
 libraries[phly-http][download][url] = "https://github.com/phly/http"

--- a/modules/primo/includes/primo.search.inc
+++ b/modules/primo/includes/primo.search.inc
@@ -1,0 +1,137 @@
+<?php
+
+/**
+ * @file
+ * Implements searching in Primo
+ */
+
+use Ting\Search\TingSearchRequest;
+
+// TODO Remove this once Primo search provider is fully implemented.
+// Ding does not support mixing multiple partial implementations of a provider
+// so we fall back to OpenSearch while we implement Primo. Thus we need to
+// load the OpenSearch search provider manually to have the functions available
+// here.
+module_load_include('inc', 'opensearch',
+  'includes/opensearch.search');
+
+/**
+ * Get a list of material types from the Well.
+ */
+function primo_search_material_types() {
+  return opensearch_search_material_types();
+}
+
+/**
+ * Load objects from Open Search.
+ *
+ * @param string[] $ids
+ *   Array of ids to load from Open Search.
+ *
+ * @return Ting\TingObjectInterface[]
+ *   An array of loaded objects.
+ */
+function primo_search_object_load(array $ids) {
+  return opensearch_search_object_load($ids);
+}
+
+/**
+ * Load a collection from Open Search.
+ *
+ * @param string $id
+ *   Id of material to load as a collection.
+ *
+ * @return Ting\TingObjectCollectionInterface
+ *   The collection.
+ */
+function primo_search_collection_load($id) {
+  return opensearch_search_collection_load($id);
+}
+
+/**
+ * Perform a search.
+ *
+ * @param \Ting\Search\TingSearchRequest $ting_query
+ *   The query to execute.
+ *
+ * @return \Ting\Search\TingSearchResultInterface
+ *   The search result.
+ */
+function primo_search_search(TingSearchRequest $ting_query) {
+  return opensearch_search_search($ting_query);
+}
+
+/**
+ * Allows the provider to programtically filter relations.
+ *
+ * @return array
+ *   Filtered list.
+ */
+function primo_search_filter_relations($relations) {
+  return opensearch_search_filter_relations($relations);
+}
+
+/**
+ * Produce a list of relations we can handle.
+ *
+ * @return string[]
+ *   Array of supported type-titles keyed by type name.
+ */
+function primo_search_supported_relations() {
+  return opensearch_search_supported_relations();
+}
+
+/**
+ * Returns a ting_relation render-array given a TingRelation.
+ *
+ * @param \TingRelation $relation
+ *   The relation to render.
+ *
+ * @return array
+ *   The render array.
+ */
+function primo_search_render_inline_relation(TingRelation $relation) {
+  return opensearch_search_render_inline_relation($relation);
+}
+
+/**
+ * Mapping between common fields and their provider-specific name.
+ *
+ * @return array
+ *   Mapping between TingSearchCommonFields::* fields and their provider-
+ *   specific counterpart.
+ */
+function primo_search_map_common_condition_fields() {
+  return opensearch_search_map_common_condition_fields();
+}
+
+/**
+ * Constructs a TingSearchRequest based on a "reference" search query.
+ *
+ * The implementation should assume that the user has entered a string with the
+ * express purpose of finding a specific material. That is, if the string seems
+ * to match the pattern of a unique material ID, the query should be constructed
+ * to look up by id.
+ *
+ * The provider can also choose to support advanced provider-specific querying.
+ *
+ * @param string $query_string
+ *   The user-provided search query.
+ *
+ * @return \Ting\Search\TingSearchRequest
+ *   The prepared query object.
+ */
+function primo_search_prepare_reference_query($query_string) {
+  return opensearch_search_prepare_reference_query($query_string);
+}
+
+/**
+ * Provide additional sort options.
+ *
+ * @return array
+ *   List of sort options represented by their labels and a TingSearchSort
+ *   instance. Keyed by a machine-name.
+ */
+function primo_search_sort_options() {
+  return opensearch_search_sort_options();
+}

--- a/modules/primo/includes/primo.search.inc
+++ b/modules/primo/includes/primo.search.inc
@@ -5,6 +5,8 @@
  * Implements searching in Primo
  */
 
+use Primo\BriefSearch\Document;
+use Primo\Ting\Object;
 use Ting\Search\TingSearchRequest;
 
 // TODO Remove this once Primo search provider is fully implemented.
@@ -32,7 +34,11 @@ function primo_search_material_types() {
  *   An array of loaded objects.
  */
 function primo_search_object_load(array $ids) {
-  return opensearch_search_object_load($ids);
+  $client = primo_client();
+  $documents = $client->documents($ids);
+  return array_map(function(Document $document) {
+    return new Object($document);
+  }, $documents);
 }
 
 /**

--- a/modules/primo/primo.info
+++ b/modules/primo/primo.info
@@ -4,5 +4,6 @@ core = 7.x
 package = Providers
 project = primo
 dependencies[] = ding_provider
+dependencies[] = drupal_psr3
 dependencies[] = libraries
 dependencies[] = xautoload

--- a/modules/primo/primo.info
+++ b/modules/primo/primo.info
@@ -4,4 +4,5 @@ core = 7.x
 package = Providers
 project = primo
 dependencies[] = ding_provider
+dependencies[] = libraries
 dependencies[] = xautoload

--- a/modules/primo/primo.module
+++ b/modules/primo/primo.module
@@ -122,17 +122,28 @@ function primo_ting_covers($entities) {
   );
 
   try {
-    $document = primo_load_by_recordid($ids);
+    $client = primo_client();
+    $documents = $client->documents($ids);
 
-    $thumbnail_urls = array_fill_keys($ids, NULL);
+    $thumbnail_urls = array_map(function(Document $document) {
+      return $document->getThumbnailUrls();
+    }, $documents);
+
     array_walk(
       $thumbnail_urls,
-      function (&$url, $id, DOMDocument $document) {
-        $urls = primo_extract_thumbnail_urls($document, $id);
-        // We can only handle a single thumbnail per id so return the first.
-        $url = array_pop($urls);
-      },
-      $document
+      function(array &$thumbnail_urls, $record_id) {
+        $thumbnail_urls = array_filter($thumbnail_urls, function ($url) use ($record_id) {
+          // Primo may return thumbnail urls to resources which are in fact not
+          // images. In fact some are not working at all. Request each of them
+          // to remove irrelevant ones. Use HEAD as we only care about status
+          // code and content type here.
+          $client = primo_client();
+          return $client->validateThumbnail($url);
+        });
+
+        // We can only handle a single thumbnail so only use the first.
+        $thumbnail_urls = array_shift($thumbnail_urls);
+      }
     );
 
     // Splice the results back into an array mapping original ids with thumbnail
@@ -150,106 +161,6 @@ function primo_ting_covers($entities) {
   }
 
   return $covers;
-}
-
-/**
- * Load documents based on their record id.
- *
- * @param string[] $rids
- *   An array of Primo record ids.
- *
- * @return \DOMDocument
- *   A DOMDocument containing the resulting XML. This XML will contain elements
- *   for each of the requested record ids.
- *
- * @throws \Primo\Exception\TransferException
- *   Thrown if an error occurs when retrieveing data from Primo.
- */
-function primo_load_by_recordid(array $rids) {
-  $url = variable_get('primo_base_url') . '/PrimoWebServices/xservice/search/brief';
-  $params = array(
-    'institution' => variable_get('primo_institution_code'),
-    'query' => 'rid,contains,' . implode($rids, ' OR '),
-    'indx' => 1,
-    'bulkSize' => count($rids),
-  );
-
-  $request_url = url($url, array('query' => $params));
-  $result = drupal_http_request($request_url);
-
-  if (!empty($result->error)) {
-    watchdog('primo',
-      'Unable to retrieve records %ids from %url: (%code) %error',
-      array(
-        '%ids' => implode(',', $rids),
-        '%url' => $request_url,
-        '%code' => $result->code,
-        '%error' => $result->error,
-      ),
-      WATCHDOG_WARNING
-    );
-    throw new TransferException($result->error, $result->code);
-  }
-
-  $document = new DOMDocument();
-  $document->loadXML($result->data);
-
-  return $document;
-}
-
-/**
- * Extract thumbnail urls for a record in an XML document
- *
- * @param \DOMDocument $document
- *   The document containing record information.
- * @param string $id
- *   The record id for which to extract the thumbnail url.
- *
- * @return string[]
- *   An array of thumbnail urls for the record.
- */
-function primo_extract_thumbnail_urls(DOMDocument $document, $id) {
-  $xpath = new DOMXPath($document);
-  $xpath->registerNamespace(
-    's', 'http://www.exlibrisgroup.com/xsd/jaguar/search');
-  $xpath->registerNamespace(
-    'p', 'http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib');
-  $thumbnail_elements = $xpath->query('//s:DOC[.//p:recordid[.="' . $id .  '"]]//s:thumbnail'
-  );
-
-  $thumbnail_urls = [];
-  foreach ($thumbnail_elements as $thumbnail_element) {
-    $thumbnail_urls[] = $thumbnail_element->nodeValue;
-  }
-
-  // Primo results are known to include duplicates. Remove these.
-  $thumbnail_urls = array_unique($thumbnail_urls);
-
-  $thumbnail_urls = array_filter($thumbnail_urls, function ($url) use ($id) {
-    // Primo may return thumbnail urls to resources which are in fact not
-    // images. In fact some are not working at all. Request each of them to
-    // remove irrelevant ones. Use HEAD as we only care about status code and
-    // content type here.
-    $result = drupal_http_request($url, array('method' => 'HEAD'));
-    $valid_thumbnail = $result->code == 200 &&
-      stripos($result->headers['content-type'], 'image') === 0;
-
-    if (variable_get('primo_enable_logging', FALSE)) {
-      watchdog('primo', '%id: %state cover image url %url. Status: %code. Content type: %content_type',
-        array(
-          '%id' => $id,
-          '%state' => $valid_thumbnail ? t('Valid') : t('Invalid'),
-          '%url' => $url,
-          '%code' => $result->code,
-          '%content_type' => $result->headers['content-type'],
-        )
-      );
-    }
-
-    return $valid_thumbnail;
-  });
-
-  return $thumbnail_urls;
 }
 
 /**

--- a/modules/primo/primo.module
+++ b/modules/primo/primo.module
@@ -16,10 +16,9 @@ function primo_ding_provider() {
     'title' => 'Primo provider',
     'settings' => 'primo_settings_form',
     'provides' => array(
-      // TODO Remove this dummy provider when we implement proper Primo search
-      // We need to provide something to have a settings page.
-      'dummy' => array(
-        'prefix' => 'dummy',
+      'search' => array(
+        'prefix' => 'search',
+        'file' => 'includes/primo.search.inc',
       ),
     ),
   );
@@ -244,4 +243,17 @@ function primo_xautoload(LocalDirectoryAdapter $adapter) {
     'Primo',
     'src/Primo'
   );
+}
+
+/**
+ * Implements hook_module_implements_alter().
+ */
+function primo_module_implements_alter(&$implementations, $hook) {
+  // TODO Remove once the Primo provider is fully implemented
+  // Ding does not support mixing multiple partial implementations of a provider
+  // so we fall back to OpenSearch while we implement Primo. Thus we need to
+  // OpenSearch enabled but not make it act as a provider.
+  if ($hook === 'ding_provider') {
+    unset($implementations['opensearch']);
+  }
 }

--- a/modules/primo/primo.module
+++ b/modules/primo/primo.module
@@ -133,14 +133,6 @@ function primo_ting_covers($entities) {
     return $entity->ding_entity_id;
   }, $entities);
 
-  // Replace entity ids with a set of Primo ids which are known to have covers.
-  // TODO: Remove this once we have proper search integration with Primo.
-  $ids = array(
-    'ICE01_PRIMO_TEST000335901',
-    'ICE01_PRIMO_TEST001027834',
-    'ICE01_PRIMO_TEST000335895',
-  );
-
   try {
     $client = primo_client();
     $documents = $client->documents($ids);
@@ -166,14 +158,7 @@ function primo_ting_covers($entities) {
       }
     );
 
-    // Splice the results back into an array mapping original ids with thumbnail
-    // urls for Primo ids.
-    // TODO: Remove this once we have proper search integration with Primo.
-    $thumbnail_urls = array_slice($thumbnail_urls, 0, count($entities));
-    $covers = array_combine(
-      array_keys($entities),
-      array_pad($thumbnail_urls, count($entities), reset($thumbnail_urls))
-    );
+    $covers = $thumbnail_urls;
   }
   catch (TransferException $e) {
     // Do nothing. If an exception occurs then we simply to not return any

--- a/modules/primo/primo.module
+++ b/modules/primo/primo.module
@@ -6,6 +6,7 @@
  */
 
 use Drupal\xautoload\Adapter\LocalDirectoryAdapter;
+use Primo\BriefSearch\Document;
 use Primo\Exception\TransferException;
 
 /**
@@ -83,6 +84,22 @@ function primo_settings_form() {
   );
 
   return system_settings_form($form);
+}
+
+/**
+ * Get a configured client for the Primo Brief Search service ready for use.
+ *
+ * @return \Primo\BriefSearch\Client
+ *   The client.
+ */
+function primo_client() {
+  return new \Primo\BriefSearch\Client(
+    new GuzzleHttp\Client([
+      'base_uri' => variable_get('primo_base_url')
+    ]),
+    variable_get('primo_institution_code'),
+    ip_address()
+  );
 }
 
 /**
@@ -242,6 +259,50 @@ function primo_xautoload(LocalDirectoryAdapter $adapter) {
   $adapter->addPsr4(
     'Primo',
     'src/Primo'
+  );
+}
+
+/**
+ * Implements hook_libraries_info().
+ */
+function primo_libraries_info() {
+  return array(
+    'guzzle' => array(
+      'name' => 'Guzzle',
+      'vendor url' => 'https://github.com/guzzle/guzzle',
+      'download url' => 'https://github.com/guzzle/guzzle',
+      'version' => '6.2',
+      'xautoload' => function ($adapter) {
+        $adapter->composerJson('composer.json');
+      },
+    ),
+    'promises' => array(
+      'name' => 'Guzzle promises library',
+      'vendor url' => 'https://github.com/guzzle/promises',
+      'download url' => 'https://github.com/guzzle/promises',
+      'version' => '1.2',
+      'xautoload' => function ($adapter) {
+        $adapter->composerJson('composer.json');
+      },
+    ),
+    'http-message' => array(
+      'name' => 'Common interface for HTTP messages',
+      'vendor url' => 'https://github.com/php-fig/http-message',
+      'download url' => 'https://github.com/php-fig/http-message',
+      'version' => '1.0',
+      'xautoload' => function ($adapter) {
+        $adapter->composerJson('composer.json');
+      },
+    ),
+    'psr7' => array(
+      'name' => 'PSR-7 message implementation',
+      'vendor url' => 'https://github.com/guzzle/psr7',
+      'download url' => 'https://github.com/guzzle/psr7',
+      'version' => '1.3',
+      'xautoload' => function ($adapter) {
+        $adapter->composerJson('composer.json');
+      },
+    ),
   );
 }
 

--- a/modules/primo/primo.module
+++ b/modules/primo/primo.module
@@ -5,7 +5,13 @@
  * Main module file for Primo.
  */
 
+use Concat\Http\Middleware\Logger;
 use Drupal\xautoload\Adapter\LocalDirectoryAdapter;
+use Drupal\PSR3\Logger\Watchdog;
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\MessageFormatter;
+use Primo\BriefSearch\Client;
 use Primo\BriefSearch\Document;
 use Primo\Exception\TransferException;
 
@@ -93,8 +99,22 @@ function primo_settings_form() {
  *   The client.
  */
 function primo_client() {
-  return new \Primo\BriefSearch\Client(
-    new GuzzleHttp\Client([
+  $handler = HandlerStack::create();
+
+  if (variable_get('primo_enable_logging')) {
+    $watchdog = new Watchdog();
+    $watchdog->setWatchdogType('primo');
+    $formatter = new MessageFormatter(
+      'Request: {method} {uri}. Response: {code} {res_header_content-type} {res_header_content-length}'
+    );
+
+    $logger = new Logger($watchdog, $formatter);
+    $handler->push($logger, 'logger');
+  }
+
+  return new Client(
+    new GuzzleClient([
+      'handler' => $handler,
       'base_uri' => variable_get('primo_base_url')
     ]),
     variable_get('primo_institution_code'),
@@ -178,11 +198,29 @@ function primo_xautoload(LocalDirectoryAdapter $adapter) {
  */
 function primo_libraries_info() {
   return array(
+    'log' => array(
+      'name' => 'PSR Log',
+      'vendor url' => 'https://github.com/php-fig/log',
+      'download url' => 'https://github.com/php-fig/log',
+      'version' => '1.0.2',
+      'xautoload' => function ($adapter) {
+        $adapter->composerJson('composer.json');
+      },
+    ),
     'guzzle' => array(
       'name' => 'Guzzle',
       'vendor url' => 'https://github.com/guzzle/guzzle',
       'download url' => 'https://github.com/guzzle/guzzle',
       'version' => '6.2',
+      'xautoload' => function ($adapter) {
+        $adapter->composerJson('composer.json');
+      },
+    ),
+    'guzzle-log-middleware' => array(
+      'name' => 'Guzzle logging middleware',
+      'vendor url' => 'https://github.com/rtheunissen/guzzle-log-middleware',
+      'download url' => 'https://github.com/rtheunissen/guzzle-log-middleware',
+      'version' => 'v0.4.0',
       'xautoload' => function ($adapter) {
         $adapter->composerJson('composer.json');
       },

--- a/modules/primo/src/Primo/BriefSearch/Client.php
+++ b/modules/primo/src/Primo/BriefSearch/Client.php
@@ -1,0 +1,123 @@
+<?php
+
+
+namespace Primo\BriefSearch;
+
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Exception\RequestException;
+use Primo\Exception\TransferException;
+
+/**
+ * Client for the Primo Brief Search webservice
+ *
+ * @see https://developers.exlibrisgroup.com/primo/apis/webservices/xservices/search/briefsearch
+ */
+class Client {
+
+  /**
+   * The HTTP client used to access the service.
+   *
+   * @var \GuzzleHttp\ClientInterface
+   */
+  protected $httpClient;
+
+  /**
+   * Default parameters to send when accessing the service.
+   *
+   * @var array
+   */
+  protected $defaultParameters;
+
+  /**
+   * Client constructor.
+   *
+   * @param \GuzzleHttp\ClientInterface $httpClient
+   *   The HTTP client used to access the service. It should already have a
+   *   base url with the Primo protocol, hostname and port.
+   * @param string $institution
+   *   The institution code. Relevant for restricted scopes or for when
+   *   searching against Primo Central.
+   * @param string $ipAddress
+   *   The client IP. This will help to identify the institution in cases the
+   *   institution was not identified (according to the IP range associated with
+   *   the institution)
+   */
+  public function __construct(ClientInterface $httpClient, $institution, $ipAddress) {
+    $this->httpClient = $httpClient;
+    $this->defaultParameters = [
+      'institution' => $institution,
+      'ip' => $ipAddress
+    ];
+  }
+
+  /**
+   * Retrieve a single document.
+   *
+   * @param string $recordId
+   *   Record id for the document to retrive.
+   *
+   * @return \Primo\BriefSearch\Document
+   *   The corresponding document.
+   *
+   * @throws \Primo\Exception\TransferException
+   *   Thrown if an error occurs during retrieval.
+   */
+  public function document($recordId) {
+    $docs = $this->documents([$recordId]);
+    return reset($docs);
+  }
+
+  /**
+   * Retrieve multiple documents.
+   *
+   * @param string[] $recordIds
+   *   Record ids for the documents to retrive.
+   *
+   * @return \Primo\BriefSearch\Document[]
+   *   An array of the corresponding documents keyed by record id.
+   *
+   * @throws \Primo\Exception\TransferException
+   *   Thrown if an error occurs during retrieval.
+   */
+  public function documents($recordIds) {
+    $result = $this->search('rid,contains,' . implode($recordIds, ' OR '), 1, count($recordIds));
+    return $result->getDocuments();
+  }
+
+  /**
+   * Execute a search
+   *
+   * @param string $query
+   *   The raw query string
+   * @param int $offset
+   *   The offset of the search results to return. Use 1 for the first result.
+   * @param int $numResults
+   *   The number of results to return.
+   * @param array $parameters
+   *   Addition query parameters to use for the query. See documentation for what
+   *   options are available.
+   *
+   * @return \Primo\BriefSearch\Result
+   *   The search result.
+   *
+   * @throws \Primo\Exception\TransferException
+   *   If an error occurs during the execution of the search.
+   */
+  public function search($query, $offset, $numResults, $parameters = []) {
+    $parameters += [
+      'query' => $query,
+      'indx' => $offset,
+      'bulkSize' => $numResults,
+    ] + $this->defaultParameters;
+    try {
+      $response = $this->httpClient->get('PrimoWebServices/xservice/search/brief', [
+        'query' => $parameters
+      ]);
+      return new Result($response->getBody()->getContents());
+    } catch (RequestException $e) {
+      // Wrap the exception and rethrow.
+      throw new TransferException($e->getMessage(), $e->getCode(), $e);
+    }
+  }
+
+}

--- a/modules/primo/src/Primo/BriefSearch/Client.php
+++ b/modules/primo/src/Primo/BriefSearch/Client.php
@@ -120,4 +120,27 @@ class Client {
     }
   }
 
+  /**
+   * Validate a Primo thumbnail url
+   *
+   * Primo may return thumbnail urls to resources which are in fact not
+   * images. This method will check verify that a url is a valid thumbnail.
+   *
+   * @param string $url
+   *   A potential thumbnail url.
+   *
+   * @return bool
+   *   Whether the url is a valid thumbnail url.
+   */
+  public function validateThumbnail($url) {
+    // Use HEAD as we only care about status code and content type here.
+    $response = $this->httpClient->head($url);
+    // According to docs content type should be a string but is really a array
+    // with a single string entry.
+    /* @var string[] $contentType */
+    $contentType = $response->getHeader('Content-Type');
+    return $response->getStatusCode() === 200 &&
+      stripos(implode('', $contentType), 'image') === 0;
+  }
+
 }

--- a/modules/primo/src/Primo/BriefSearch/Document.php
+++ b/modules/primo/src/Primo/BriefSearch/Document.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Primo\BriefSearch;
+
+/**
+ * A document returned when accessing the Primo brief search service.
+ */
+class Document {
+  use DocumentTrait;
+
+  /**
+   * The id of the document.
+   *
+   * @var string
+   */
+  protected $recordId;
+
+  /**
+   * Document constructor.
+   *
+   * @param \DOMDocument $document
+   *   The XML search response document which contains the current document.
+   * @param string $recordId
+   *   Document record id.
+   */
+  public function __construct(\DOMDocument $document, $recordId) {
+    $this->document = $document;
+    $this->recordId = $recordId;
+  }
+
+  /**
+   * Get the record id for the document.
+   *
+   * @return string
+   *   Document record id.
+   */
+  public function getRecordId() {
+    return $this->recordId;
+  }
+
+  /**
+   * Get all thumbnail urls for the document.
+   *
+   * @return string[]
+   *   Thumbnail urls.
+   */
+  public function getThumbnailUrls() {
+    $thumbnailNodes = $this->recordXpath($this->recordId, '//search:thumbnail');
+    $thumbnailUrls = $this->nodeValues($thumbnailNodes);
+
+    // Primo results are known to include duplicates urls. Remove these.
+    return array_unique($thumbnailUrls);
+  }
+
+}

--- a/modules/primo/src/Primo/BriefSearch/Document.php
+++ b/modules/primo/src/Primo/BriefSearch/Document.php
@@ -4,6 +4,10 @@ namespace Primo\BriefSearch;
 
 /**
  * A document returned when accessing the Primo brief search service.
+ *
+ * A central part of the document is the PNX record.
+ *
+ * @see https://knowledge.exlibrisgroup.com/Primo/Product_Documentation/Technical_Guide/010The_PNX_Record
  */
 class Document {
   use DocumentTrait;
@@ -39,6 +43,82 @@ class Document {
   }
 
   /**
+   * This ID identifies the record in the source repository.
+   *
+   * A source repository could be an ALEPH system number supplied in MARC 21 tag
+   * 001). The ID must be unique and persistent within the source repository.
+   * It is derived from the OAI header.
+   *
+   * @return string
+   *   Source record id.
+   */
+  public function getSourceRecordId() {
+    $nodes = $this->recordXpath($this->recordId, '//primo:control/primo:sourcerecordid');
+    return $this->nodeValue($nodes);
+  }
+
+  /**
+   * Returns the full version of the document title.
+   *
+   * @return string
+   *   Document title.
+   */
+  public function getTitle() {
+    $nodes = $this->recordXpath($this->recordId, '//primo:display/primo:title');
+    return $this->nodeValue($nodes);
+  }
+
+  /**
+   * Returns a short version of the document title.
+   *
+   * @return string
+   *   Document title.
+   */
+  public function getBriefTitle() {
+    $nodes = $this->recordXpath($this->recordId, '//primo:adddata/primo:btitle');
+    return $this->nodeValue($nodes);
+  }
+
+
+  /**
+   * Returns a extended description of the document.
+   *
+   * @return string
+   *   Document description.
+   */
+  public function getDescription() {
+    $nodes = $this->recordXpath($this->recordId, '//primo:display/primo:description');
+    return $this->nodeValue($nodes);
+  }
+
+  /**
+   * Returns the display format for the document.
+   *
+   * This will contain information about the physical format of the document
+   * e.g.number of pages, illustrations and such.
+   *
+   * @return string
+   *   Display format description.
+   */
+  public function getDisplayFormat() {
+    $nodes = $this->recordXpath($this->recordId, '//primo:display/primo:format');
+    return $this->nodeValue($nodes);
+  }
+
+  /**
+   * Return ISBN numbers for the record.
+   *
+   * Note that a Primo record can contain multiple ISBN numbers - both ISBN-10
+   * and ISBN-13.
+   *
+   * @return string[]
+   */
+  public function getIsbns() {
+    $nodes = $this->recordXpath($this->recordId, '//primo:addata/primo:isbn');
+    return $this->nodeValues($nodes);
+  }
+
+  /**
    * Get all thumbnail urls for the document.
    *
    * @return string[]
@@ -50,6 +130,51 @@ class Document {
 
     // Primo results are known to include duplicates urls. Remove these.
     return array_unique($thumbnailUrls);
+  }
+
+  /**
+   * Return document publisher name.
+   *
+   * @return string
+   *   Publisher name.
+   */
+  public function getPublisher() {
+    $nodes = $this->recordXpath($this->recordId, '//primo:addata/primo:pub');
+    return $this->nodeValue($nodes);
+  }
+
+  /**
+   * Returns the publishing year for the document.
+   *
+   * @return string
+   *   Publishing year.
+   */
+  public function getYear() {
+    $nodes = $this->recordXpath($this->recordId, '//primo:addata/primo:date');
+    return $this->nodeValue($nodes);
+  }
+
+  /**
+   * Gets the value of a local display field.
+   *
+   * Primo supports local fields which are represented as XML elements named
+   * lds[XX]. This allows extraction of such fields.
+   *
+   * @see https://knowledge.exlibrisgroup.com/Primo/Product_Documentation/Back_Office_Guide/110Additional_Primo_Features/Display_of_Local_Fields
+   *
+   * @return string
+   *   Local display field value
+   */
+  public function getLocalDisplayField($number) {
+    $nodes = $this->recordXpath($this->recordId,
+      '//primo:display/primo:lds' .
+      str_pad($number, 2, 0,  STR_PAD_LEFT));
+    return $this->nodeValue($nodes);
+  }
+
+  public function getFormat() {
+    $nodes = $this->recordXpath($this->recordId, '//primo:addata/primo:format');
+    return $this->nodeValue($nodes);
   }
 
 }

--- a/modules/primo/src/Primo/BriefSearch/DocumentTrait.php
+++ b/modules/primo/src/Primo/BriefSearch/DocumentTrait.php
@@ -54,12 +54,37 @@ trait DocumentTrait {
     return $this->xpath($query);
   }
 
+  /**
+   * Retrieves values from a node list.
+   *
+   * @param \DOMNodeList $list
+   *   The node list.
+   *
+   * @return string[]
+   *   The node values.
+   */
   protected function nodeValues(\DOMNodeList $list) {
     $values = [];
     foreach ($list as $node) {
       $values[] = $node->nodeValue;
     }
     return $values;
+  }
+
+  /**
+   * Retrieves the first value from a node list.
+   *
+   * All subsequent values are discarded.
+   *
+   * @param \DOMNodeList $list
+   *   The node list.
+   *
+   * @return string
+   *   The value of the first node.
+   */
+  protected function nodeValue(\DOMNodeList $list) {
+    $values = $this->nodeValues($list);
+    return reset($values);
   }
 
 }

--- a/modules/primo/src/Primo/BriefSearch/DocumentTrait.php
+++ b/modules/primo/src/Primo/BriefSearch/DocumentTrait.php
@@ -1,0 +1,65 @@
+<?php
+
+
+namespace Primo\BriefSearch;
+
+/**
+ * Trait used for accessing data with a Primo brief search result document.
+ */
+trait DocumentTrait {
+
+  /**
+   * The Primo brief search result document.
+   *
+   * @var \DOMDocument
+   */
+  protected $document;
+
+  /**
+   * Perform a xpath query against the document.
+   *
+   * The xpath will have helpful Primo related namespaces registered:
+   * - search: http://www.exlibrisgroup.com/xsd/jaguar/search
+   * - primo: http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib
+   *
+   * @param string $query
+   *   The XPath query
+   * @return \DOMNodeList
+   *   The result of the xpath query.
+   */
+  protected function xpath($query) {
+    $xpath = new \DOMXPath($this->document);
+    $xpath->registerNamespace(
+      'search', 'http://www.exlibrisgroup.com/xsd/jaguar/search');
+    $xpath->registerNamespace(
+      'primo', 'http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib');
+    return $xpath->query($query);
+  }
+
+  /**
+   * Perform a xpath query against a record contained with the document.
+   *
+   * A document may contain multiple records. This is a neat way to focus
+   * solely on a single record.
+   *
+   * @param string $recordId
+   *   The document record id.
+   * @param string $query
+   *
+   * @return \DOMNodeList
+   *   The result of thr xpath query.
+   */
+  protected function recordXpath($recordId, $query) {
+    $query = '//search:DOC[.//primo:recordid[.="' . $recordId .  '"]]' . $query;
+    return $this->xpath($query);
+  }
+
+  protected function nodeValues(\DOMNodeList $list) {
+    $values = [];
+    foreach ($list as $node) {
+      $values[] = $node->nodeValue;
+    }
+    return $values;
+  }
+
+}

--- a/modules/primo/src/Primo/BriefSearch/Result.php
+++ b/modules/primo/src/Primo/BriefSearch/Result.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Primo\BriefSearch;
+
+/**
+ * A result from accesing the Primo brief search servide.
+ */
+class Result {
+  use DocumentTrait;
+
+  /**
+   * Result constructor.
+   *
+   * @param string $data
+   *   The data returned from Primo.
+   */
+  public function __construct($data) {
+    $this->document = new \DOMDocument();
+    $this->document->loadXML($data);
+  }
+
+  /**
+   * Extracts the documents returned within the search result.
+   *
+   * @return \Primo\BriefSearch\Document[]
+   *   The resulting documents.
+   */
+  public function getDocuments() {
+    $recordIdNodes = $this->xpath('//search:DOC//primo:control/primo:recordid');
+    $recordIds = $this->nodeValues($recordIdNodes);
+
+    $documents = array_map(function($recordId) {
+      return new Document($this->document, $recordId);
+    }, array_combine($recordIds, $recordIds));
+
+    return $documents;
+  }
+
+
+}

--- a/modules/primo/src/Primo/BriefSearch/Result.php
+++ b/modules/primo/src/Primo/BriefSearch/Result.php
@@ -3,7 +3,7 @@
 namespace Primo\BriefSearch;
 
 /**
- * A result from accesing the Primo brief search servide.
+ * A result from accessing the Primo brief search service.
  */
 class Result {
   use DocumentTrait;

--- a/modules/primo/src/Primo/Ting/Object.php
+++ b/modules/primo/src/Primo/Ting/Object.php
@@ -1,0 +1,274 @@
+<?php
+
+
+namespace Primo\Ting;
+
+
+use Primo\BriefSearch\Document;
+use Ting\TingObjectInterface;
+
+/**
+ * Ting Object implementation for Primo.
+ *
+ * This class acts as a wrapper around a Primo document and exposes methods
+ * which will extract data required by Ting.
+ */
+class Object implements TingObjectInterface {
+
+  /**
+   * The Primo document which the object represents.
+   *
+   * @var \Primo\BriefSearch\Document
+   */
+  protected $document;
+
+  /**
+   * Object constructor.
+   *
+   * @param \Primo\BriefSearch\Document $document
+   *   The Primo document to wrap.
+   */
+  public function __construct(Document $document) {
+    $this->document = $document;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function getId() {
+    return $this->document->getRecordId();
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function getSourceId() {
+    return $this->document->getSourceRecordId();
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function isLocal() {
+    // TODO: Implement isLocal() method.
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function getOwnerId() {
+    // TODO: Implement getOwnerId() method.
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function getTitle() {
+    return $this->document->getTitle();
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function getShortTitle() {
+    return $this->document->getBriefTitle();
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function getDescription() {
+    return $this->document->getDescription();
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function getRelations() {
+    // TODO: Implement getRelations() method.
+  }
+
+
+  /**
+   * @inheritDoc
+   */
+  public function getAge() {
+    // TODO: Implement getAge() method.
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function getAudience() {
+    // TODO: Implement getAudience() method.
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function getExtent() {
+    return $this->document->getDisplayFormat();
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function getFormat() {
+    // TODO: Implement getFormat() method.
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function getGenere() {
+    // TODO: Implement getGenere() method.
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function getIsbn() {
+    // A Primo record may contain multiple ISBNs - ISBN-10 and ISBN-13.
+    // Ding2 only works with a single ISBN value for an object and we prefer
+    // ISBN-13 so sort values by length and return the longest.
+    $isbns = $this->document->getIsbns();
+    usort($isbns, function($a, $b) {
+      return strlen($b) - strlen($a);
+    });
+    return reset($isbns);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function getMusician() {
+    // TODO: Implement getMusician() method.
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function getPegi() {
+    // TODO: Implement getPegi() method.
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function getPublisher() {
+    return $this->document->getPublisher();
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function getReferenced() {
+    // TODO: Implement getReferenced() method.
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function getReplacedBy() {
+    // TODO: Implement getReplacedBy() method.
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function getReplaces() {
+    // TODO: Implement getReplaces() method.
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function getRights() {
+    // TODO: Implement getRights() method.
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function getSeriesDescription() {
+    // TODO: Implement getSeriesDescription() method.
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function getSource() {
+    $source = $this->document->getLocalDisplayField(6);
+    // Source texts may contain the text 'Á frummáli: ' meaning 'In the original
+    // language'. However such a prefix will be added by the calling code so
+    // we remove it here.
+    // Note that this is strictly tied to how Primo is used by Icelandic
+    // libraries.
+    return str_replace('Á frummáli: ', '', $source);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function getSpatial() {
+    // TODO: Implement getSpatial() method.
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function getSpoken() {
+    // TODO: Implement getSpoken() method.
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function getSubTitles() {
+    // TODO: Implement getSubTitles() method.
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function getTracks() {
+    // TODO: Implement getTracks() method.
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function getURI() {
+    // TODO: Implement getURI() method.
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function getVersion() {
+    // Do nothing. Primo does not distinguish between difference versions of
+    // the same object.
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function isPartOf() {
+    // TODO: Implement isPartOf() method.
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function getType() {
+    return $this->document->getFormat();
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function getYear() {
+    return $this->document->getYear();
+  }
+
+}


### PR DESCRIPTION
This PR contains the first stab at loading materials from Primo.

It consists of the following parts:

- A stub implementation of the Primo `search` provider. This will bounce calls back to OpenSearch if they are not implemented by Primo
- A proper client library for communicating with the Primo Brief Search webservice
- An implementation of the `search_object_load` provider hook and initial implementation of `TingObjectInterface` for Primo
- Logging of requests
- Proper retrival for covers