### PR TITLE
Feature/bbs 193 simplify filters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,5 +48,7 @@ circle-run-unit-tests:
 	cd $(DRUPAL_SITE_PATH) && php scripts/run-tests.sh --php /opt/circleci/.phpenv/shims/php --xml $(CIRCLE_TEST_REPORTS)/phpunit \
 	  "Ding! - Ting search unittest"
 	cd $(DRUPAL_SITE_PATH) && php scripts/run-tests.sh --php /opt/circleci/.phpenv/shims/php --xml $(CIRCLE_TEST_REPORTS)/phpunit \
+	  "Opensearch"
+	cd $(DRUPAL_SITE_PATH) && php scripts/run-tests.sh --php /opt/circleci/.phpenv/shims/php --xml $(CIRCLE_TEST_REPORTS)/phpunit \
 	  --class ConnieSearchSearchProviderImplementationTestCase
 

--- a/modules/opensearch/includes/opensearch.search.inc
+++ b/modules/opensearch/includes/opensearch.search.inc
@@ -4,14 +4,13 @@
  * Implements handling of loans through OpenRuth.
  */
 
+use OpenSearch\OpenSearchStatementGroupRender;
 use OpenSearch\OpenSearchTingObject;
 use OpenSearch\OpenSearchTingObjectCollection;
 use OpenSearch\OpenSearchTingSearchResult;
 use Ting\Search\DingProviderStrategy;
 use Ting\Search\SearchProviderException;
-use Ting\Search\StatementGroupRender;
 use Ting\Search\TingSearchCommonFields;
-use Ting\Search\TingSearchCommonSortFields;
 use Ting\Search\TingSearchRequest;
 use Ting\Search\TingSearchSort;
 
@@ -117,8 +116,15 @@ function opensearch_search_search(TingSearchRequest $ting_query) {
 
   // Add field filter.
   if (!empty($ting_query->getFieldFilters())) {
-    $render = new StatementGroupRender(new DingProviderStrategy());
-    $field_filters = $render->renderStatements($ting_query->getFieldFilters());
+    $render = new OpenSearchStatementGroupRender(new DingProviderStrategy());
+    try {
+      $field_filters = $render->renderStatements(
+        $ting_query->getFieldFilters()
+      );
+    }
+    catch (InvalidArgumentException $e) {
+      throw new SearchProviderException("Unable to render statements", 0, $e);
+    }
     $query_parts[] = $field_filters;
   }
 

--- a/modules/opensearch/opensearch.info
+++ b/modules/opensearch/opensearch.info
@@ -7,4 +7,5 @@ project = opensearch
 dependencies[] = ding_provider
 dependencies[] = xautoload
 files[] = lib/ting-client/**
+files[] = opensearch_unit.test
 configure = admin/config/opensearch

--- a/modules/opensearch/opensearch.module
+++ b/modules/opensearch/opensearch.module
@@ -405,5 +405,5 @@ function opensearch_search_autocomplete_settings() {
  * Place our OpenSearch classes in the OpenSearch namespace.
  */
 function opensearch_xautoload(LocalDirectoryAdapter $adapter) {
-  $adapter->absolute()->addPsr4('OpenSearch\\', drupal_get_path('module', 'opensearch') . '/src');
+  $adapter->addPsr4('OpenSearch', 'src');
 }

--- a/modules/opensearch/opensearch_unit.test
+++ b/modules/opensearch/opensearch_unit.test
@@ -1,0 +1,97 @@
+<?php
+/**
+ * @file
+ * Unittests for Opensearch.
+ */
+
+use Drupal\ding_test\DingUnitTestBase;
+use OpenSearch\OpenSearchStatementGroupRender;
+use Ting\Search\BooleanStatementGroup;
+use Ting\Search\BooleanStatementInterface;
+use Ting\Search\TingSearchCommonFields;
+use Ting\Search\TingSearchFieldFilter;
+use Ting\Search\TingSearchStrategyInterface;
+
+class OpensearchUnitTest extends DingUnitTestBase {
+  public static function getInfo() {
+    return [
+      'name' => 'Opensearch Unittests',
+      'description' => 'Unit-tests that tests the opensearch module.',
+      'group' => 'Opensearch',
+      'dependencies' => ['opensearch'],
+    ];
+  }
+
+  /**
+   * Setup autoloading.
+   */
+  public function setUp() {
+    // Parent sets up autoloading and our test-dependencies so get it in the
+    // loop as quickly as possible.
+    parent::setUp();
+
+    // Any subsequent setup goes here.
+  }
+
+  /**
+   * Test that the StatementGroupRender can render a nested group.
+   *
+   * @throws \Exception
+   */
+  public function testStatementGroupRenderer() {
+    // The final query-string the arrangement of groupings and fields below
+    // should end up as. Notice that we use mapped fields.
+    $expected_result = '(test_author="1" AND test_subject="2") OR test_category="3\"" OR ((test_language OR test_author="5") AND (test_subject="6" OR test_category="7"))';
+
+    // Build the query, use the common names that will have to be mapped in
+    // order to match the expected output.
+    // Setup an "AND" group.
+    $group1 = new BooleanStatementGroup([
+      new TingSearchFieldFilter(TingSearchCommonFields::AUTHOR, 1),
+      new TingSearchFieldFilter(TingSearchCommonFields::SUBJECT, 2),
+    ], BooleanStatementInterface::OP_AND);
+
+    // Standalone field.
+    $field2 = new TingSearchFieldFilter(TingSearchCommonFields::CATEGORY, '3"');
+
+    // Group 4 (an OR group) is nested inside group 3 so we define it first.
+    $group4 = new BooleanStatementGroup([
+      // Test boolean field behaviour (that is: this field should be rendered
+      // without the comparison).
+      new TingSearchFieldFilter(TingSearchCommonFields::LANGUAGE),
+      new TingSearchFieldFilter(TingSearchCommonFields::AUTHOR, 5)
+    ], BooleanStatementInterface::OP_OR);
+
+    // Group 5 (an AND group) is nested inside group 3 so we define it first.
+    $group5 = new BooleanStatementGroup([
+      new TingSearchFieldFilter(TingSearchCommonFields::SUBJECT, 6),
+      new TingSearchFieldFilter(TingSearchCommonFields::CATEGORY, 7),
+    ], BooleanStatementInterface::OP_OR);
+
+    // Join group 4 and 5 together with an AND group.
+    $group3 = new BooleanStatementGroup([$group4, $group5], BooleanStatementInterface::OP_AND);
+
+    $groups = [$group1, $field2, $group3];
+
+    // Setup a renderer configured to use our own mapping of fields.
+    $strategy_double = $this->prophet->prophesize(TingSearchStrategyInterface::class);
+    $mapping = [
+      TingSearchCommonFields::AUTHOR => 'test_author',
+      TingSearchCommonFields::SUBJECT => 'test_subject',
+      TingSearchCommonFields::CATEGORY => 'test_category',
+      TingSearchCommonFields::LANGUAGE => 'test_language',
+    ];
+    $strategy_double->mapCommonFields()->willReturn($mapping);
+    $strategy = $strategy_double->reveal();
+
+    $renderer = new OpenSearchStatementGroupRender($strategy);
+
+    // Test that adding a single group around a list does not affect redering.
+    $filter_string_wrapped = $renderer->renderGroup((new BooleanStatementGroup($groups, BooleanStatementInterface::OP_OR)));
+    $filter_string_from_list = $renderer->renderStatements($groups, BooleanStatementInterface::OP_OR);
+    $this->assertEqual($filter_string_from_list, $filter_string_wrapped, "List of filters is rendered the same way as a list wrapped in a group.");
+
+    // Test that the query ends up as we expect.
+    $this->assertEqual($expected_result, $filter_string_wrapped);
+  }
+}

--- a/modules/opensearch/src/OpenSearchStatementGroupRender.php
+++ b/modules/opensearch/src/OpenSearchStatementGroupRender.php
@@ -4,15 +4,19 @@
  * The StatementGroupRender class.
  */
 
-namespace Ting\Search;
+namespace OpenSearch;
+
+use Ting\Search\BooleanStatementGroup;
+use Ting\Search\BooleanStatementInterface;
+use Ting\Search\TingSearchCommonFields;
+use Ting\Search\TingSearchFieldFilter;
 
 /**
- * Class TingFilterGroupRendere
  * Recursivly renders a statement group
  *
  * @package Ting\Search
  */
-class StatementGroupRender {
+class OpenSearchStatementGroupRender {
   // Provider-specific mapping, intialized during field rendering.
   protected $commonFieldMapping = NULL;
 
@@ -35,7 +39,7 @@ class StatementGroupRender {
    * @return string
    *   The rendered group, empty string if the group is empty.
    *
-   * @throws \Exception
+   * @throws \InvalidArgumentException
    *   In case the group contains invalid members.
    */
   public function renderGroup($group) {
@@ -56,7 +60,7 @@ class StatementGroupRender {
    * @return string
    *   The rendered group, empty string if the group is empty.
    *
-   * @throws \Exception
+   * @throws \InvalidArgumentException
    *   In case the group contains invalid members.
    */
   public function renderStatements($statements, $logic_operator = BooleanStatementInterface::OP_AND) {
@@ -154,7 +158,7 @@ class StatementGroupRender {
     // TODO BBS-SAL: escape field value - again using the provider.
 
     // Map the field if it is a common-field.
-    if (in_array($field->getName(), TingSearchCommonFields::getAll())) {
+    if (in_array($field->getName(), TingSearchCommonFields::getAll(), TRUE)) {
       if (isset($this->commonFieldMapping[$field->getName()])) {
         $field_name = $this->commonFieldMapping[$field->getName()];
       }
@@ -180,6 +184,6 @@ class StatementGroupRender {
     $quoted_field = '"' . str_replace('"', '\"', $field->getValue()) . '"';
 
     // Render the full field with operator and value.
-    return $field_name . $field->getOperator() . $quoted_field;
+    return $field_name . '=' . $quoted_field;
   }
 }

--- a/modules/p2/ding_serendipity_ting_entity/ding_serendipity_ting_entity.module
+++ b/modules/p2/ding_serendipity_ting_entity/ding_serendipity_ting_entity.module
@@ -154,7 +154,7 @@ function ding_serendipity_ting_entity_ting_object_subject_serendipity_add($conte
 
   // Find related content from any of the subjects.
   $field_filters = array_map(function($subject) {
-    return new TingSearchFieldFilter(TingSearchCommonFields::SUBJECT, $subject, '=');
+    return new TingSearchFieldFilter(TingSearchCommonFields::SUBJECT, $subject);
   }, $subjects);
 
   $query = ting_start_query()->addFieldFilters($field_filters, BooleanStatementInterface::OP_OR);

--- a/modules/ting/src/Search/TingSearchFieldFilter.php
+++ b/modules/ting/src/Search/TingSearchFieldFilter.php
@@ -26,13 +26,6 @@ class TingSearchFieldFilter {
   protected $name;
 
   /**
-   * The operator used to compare the field instance and value.
-   *
-   * @var string
-   */
-  protected $operator;
-
-  /**
    * Field value.
    *
    * If TingSearchFieldFilter::BOOLEAN_FIELD_VALUE the field is a boolean field.
@@ -44,25 +37,19 @@ class TingSearchFieldFilter {
   /**
    * TingSearchFieldFilter constructor.
    *
-   * TODO BBS-SAL: Consider handling the $operator via an enum.
-   *
    * @param string $name
    *   The field name.
    *
    * @param mixed|TingSearchFieldFilter::BOOLEAN_FIELD_VALUE $value
-   *   Field value, if omitted or set to
+   *   Expected field-value, if omitted or set to
    *   TingSearchFieldFilter::BOOLEAN_FIELD_VALUE the field is treated as a
    *   boolean field that will be compared without an operator Eg:
    *   (myboolfield AND anotherfield=123)
-   * @param string $operator
-   *   Operator to use when comparing the field instance with a value.
    */
-  public function __construct($name, $value = self::BOOLEAN_FIELD_VALUE, $operator = '=') {
+  public function __construct($name, $value = self::BOOLEAN_FIELD_VALUE) {
     $this->name = $name;
-    $this->operator = $operator;
     $this->value = $value;
   }
-
 
   /**
    * Returns the name of the field.
@@ -72,16 +59,6 @@ class TingSearchFieldFilter {
    */
   public function getName() {
     return $this->name;
-  }
-
-  /**
-   * Returns the operator to be used when evaluating the field.
-   *
-   * @return string
-   *   The operator.
-   */
-  public function getOperator() {
-    return $this->operator;
   }
 
   /**

--- a/modules/ting/src/Search/TingSearchRequest.php
+++ b/modules/ting/src/Search/TingSearchRequest.php
@@ -432,8 +432,10 @@ class TingSearchRequest {
   /**
    * Get the list of BooleanStatementGroup instances.
    *
+   * When executed the statements must be joined together with a logical AND.
+   *
    * @return BooleanStatementGroup[]
-   *   List of BooleanStatementGroup intances used to filter field.
+   *   List of BooleanStatementGroup instances used to filter field.
    */
   public function getFieldFilters() {
     return $this->fieldFilters;
@@ -442,13 +444,16 @@ class TingSearchRequest {
   /**
    * Filter(s) or statement group(s) to add to the query.
    *
+   * If the query already contains filters, the filters specified in $filters
+   * will be AND'ed with the existing filters.
+   *
    * @param mixed[]|\Ting\Search\BooleanStatementGroup|\Ting\Search\TingSearchFieldFilter $filters
    *   A single BooleanStatementGroup or TingSearchFieldFilter or a (potentially
    *   mixed) array of both.
    *
    * @param string $logic_operator
-   *   Operator to apply if this is not the first statement. See
-   *   BooleanStatementInterface::OP_*
+   *   Logical operator to use for joining filters together if $filters contains
+   *   more than one filter. See BooleanStatementInterface::OP_*.
    *
    * @return TingSearchRequest
    *   the current query object.
@@ -488,18 +493,16 @@ class TingSearchRequest {
    *   The field name.
    *
    * @param mixed|TingSearchFieldFilter::BOOLEAN_FIELD_VALUE $value
-   *   Field value, if omitted or set to
+   *   Expected field-value, if omitted or set to
    *   TingSearchFieldFilter::BOOLEAN_FIELD_VALUE the field is treated as a
    *   boolean field that will be compared without an operator Eg:
    *   (myboolfield AND anotherfield=123)
-   * @param string $operator
-   *   Operator to use when comparing the field instance with a value.
    *
    * @return TingSearchRequest
    *   the current query object.
    */
-  public function addFieldFilter($name, $value = TingSearchFieldFilter::BOOLEAN_FIELD_VALUE, $operator = '=') {
-    $this->addFieldFilters([new TingSearchFieldFilter($name, $value, $operator)]);
+  public function addFieldFilter($name, $value = TingSearchFieldFilter::BOOLEAN_FIELD_VALUE) {
+    $this->addFieldFilters([new TingSearchFieldFilter($name, $value)]);
     return $this;
   }
 }

--- a/modules/ting_search/tests/ting_search_unit.test
+++ b/modules/ting_search/tests/ting_search_unit.test
@@ -4,7 +4,6 @@ use Drupal\ding_test\DingUnitTestBase;
 use Prophecy\Argument;
 use Ting\Search\BooleanStatementGroup;
 use Ting\Search\BooleanStatementInterface;
-use Ting\Search\StatementGroupRender;
 use Ting\Search\TingSearchCommonFields;
 use Ting\Search\TingSearchFieldFilter;
 use Ting\Search\TingSearchRequest;
@@ -42,68 +41,6 @@ class DingSearchUnitTest extends DingUnitTestBase {
     $clientInstance = $clientDouble->reveal();
     $response = $clientInstance->request("GET", "http://example.com");
     $this->assertEqual($response->getBody(), "Hello World");
-  }
-
-  /**
-   * Test that the StatementGroupRender can render a nested group.
-   *
-   * @throws \Exception
-   */
-  public function testStatementGroupRenderer() {
-    // The final query-string the arrangement of groupings and fields below
-    // should end up as. Notice that we use mapped fields.
-    $expected_result = '(test_author<"1" AND test_subject>"2") OR test_category="3\"" OR ((test_language OR test_author="5") AND (test_subject="6" OR test_category="7"))';
-
-    // Build the query, use the common names that will have to be mapped in
-    // order to match the expected output.
-    // Setup an "AND" group.
-    $group1 = new BooleanStatementGroup([
-      new TingSearchFieldFilter(TingSearchCommonFields::AUTHOR, 1, '<'),
-      new TingSearchFieldFilter(TingSearchCommonFields::SUBJECT, 2, '>'),
-    ], BooleanStatementInterface::OP_AND);
-
-    // Standalone field.
-    $field2 = new TingSearchFieldFilter(TingSearchCommonFields::CATEGORY, '3"');
-
-    // Group 4 (an OR group) is nested inside group 3 so we define it first.
-    $group4 = new BooleanStatementGroup([
-      // Test boolean field behaviour (that is: this field should be rendered
-      // without the comparison).
-      new TingSearchFieldFilter(TingSearchCommonFields::LANGUAGE),
-      new TingSearchFieldFilter(TingSearchCommonFields::AUTHOR, 5)
-    ], BooleanStatementInterface::OP_OR);
-
-    // Group 5 (an AND group) is nested inside group 3 so we define it first.
-    $group5 = new BooleanStatementGroup([
-      new TingSearchFieldFilter(TingSearchCommonFields::SUBJECT, 6),
-      new TingSearchFieldFilter(TingSearchCommonFields::CATEGORY, 7),
-    ], BooleanStatementInterface::OP_OR);
-
-    // Join group 4 and 5 together with an AND group.
-    $group3 = new BooleanStatementGroup([$group4, $group5], BooleanStatementInterface::OP_AND);
-
-    $groups = [$group1, $field2, $group3];
-
-    // Setup a renderer configured to use our own mapping of fields.
-    $strategy_double = $this->prophet->prophesize(TingSearchStrategyInterface::class);
-    $mapping = [
-      TingSearchCommonFields::AUTHOR => 'test_author',
-      TingSearchCommonFields::SUBJECT => 'test_subject',
-      TingSearchCommonFields::CATEGORY => 'test_category',
-      TingSearchCommonFields::LANGUAGE => 'test_language',
-    ];
-    $strategy_double->mapCommonFields()->willReturn($mapping);
-    $strategy = $strategy_double->reveal();
-
-    $renderer = new StatementGroupRender($strategy);
-
-    // Test that adding a single group around a list does not affect redering.
-    $filter_string_wrapped = $renderer->renderGroup((new BooleanStatementGroup($groups, BooleanStatementInterface::OP_OR)));
-    $filter_string_from_list = $renderer->renderStatements($groups, BooleanStatementInterface::OP_OR);
-    $this->assertEqual($filter_string_from_list, $filter_string_wrapped, "List of filters is rendered the same way as a list wrapped in a group.");
-
-    // Test that the query ends up as we expect.
-    $this->assertEqual($expected_result, $filter_string_wrapped);
   }
 
   /**


### PR DESCRIPTION
Simplify SAL to make it more Primo compatible by
- Moving field and group rendering completely into opensearch, thus making it possible for Primo to do it's own rendering
- Remove the option of specifying an operator when specifying field filteres instead falling back to equallity. Thus making it possible for Primo to implement all field filters with the "exactly" precision

BBS-193