### PR TITLE
Fix handling of location scope.

### DIFF
--- a/modules/primo/primo.module
+++ b/modules/primo/primo.module
@@ -154,7 +154,7 @@ function primo_client() {
     ]),
     variable_get('primo_institution_code'),
     ip_address(),
-    variable_get('primo_location_scopes', [])
+    variable_get('primo_location_scopes', '')
   );
 }
 


### PR DESCRIPTION
The log was spammed with errors because the `locationScope` property was given an array.
Primo doesn't like "Array" in the query. 😉 