### PR TITLE
BBS-161: Search sources provider

### DIFF
--- a/modules/ding_availability/ding_availability.admin.inc
+++ b/modules/ding_availability/ding_availability.admin.inc
@@ -40,7 +40,7 @@ function ding_availability_admin_holdings_settings($form_state) {
   $form['ding_availability_holdings']['ding_availability_holdings_types'] = array(
     '#type' => 'checkboxes',
     '#title' => t('Types'),
-    '#options' => drupal_map_assoc(array_keys($types)),
+    '#options' => drupal_map_assoc($types),
     '#default_value' => variable_get('ding_availability_holdings_types', _ding_availability_holdings_default_types()),
   );
   // Save us the trouble of running array_filter.

--- a/modules/ding_provider/connie_search/connie_search.test
+++ b/modules/ding_provider/connie_search/connie_search.test
@@ -46,6 +46,15 @@ class ConnieSearchSearchProviderImplementationTestCase extends DingSearchProvide
   }
 
   /**
+   * Expected return value of search_sources.
+   *
+   * @return string[]
+   *   List of expected sources.
+   */
+  public function getSources() {
+    return ['source A', 'source B'];
+  }
+  /**
    * Expected return-value of search_object_load.
    *
    * @return \Ting\TingObjectInterface[]

--- a/modules/ding_provider/connie_search/includes/connie_search.search.inc
+++ b/modules/ding_provider/connie_search/includes/connie_search.search.inc
@@ -21,6 +21,15 @@ function connie_search_search_material_types() {
   return ['material_type_1', 'material_type_2'];
 }
 
+/**
+ * Get a list of search sources.
+ *
+ * @return string[]
+ *   List of search sources.
+ */
+function connie_search_search_sources() {
+  return ['source A', 'source B'];
+}
 
 /**
  * Load objects from Open Search.

--- a/modules/ding_provider/tests/ding_provider_implementation.test
+++ b/modules/ding_provider/tests/ding_provider_implementation.test
@@ -348,6 +348,14 @@ abstract class DingSearchProviderImplementationTestCase extends DingProviderImpl
   public abstract function getMaterials();
 
   /**
+   * Provide a list of expected sources.
+   *
+   * @return string[]
+   *   Simple array of sources.
+   */
+  public abstract function getSources();
+
+  /**
    * Expected return-value of search_object_load.
    *
    * @return object[]
@@ -450,6 +458,15 @@ abstract class DingSearchProviderImplementationTestCase extends DingProviderImpl
     $expected_materials = $this->getMaterials();
     $materials_from_provider = ding_provider_invoke('search', 'material_types');
     $this->assertEqual($expected_materials, $materials_from_provider);
+  }
+  
+  /**
+   * Verify that the provider returns the expected list of sources.
+   */
+  public function testSources() {
+    $expected_sources = $this->getSources();
+    $sources_from_provider = ding_provider_invoke('search', 'sources');
+    $this->assertEqual($expected_sources, $sources_from_provider);
   }
 
   /**

--- a/modules/opensearch/includes/opensearch.search.inc
+++ b/modules/opensearch/includes/opensearch.search.inc
@@ -53,12 +53,9 @@ function _opensearch_get_facet_values($facet_name) {
   ];
   $result = opensearch_do_search("*", 0, 0, $options);
 
-  $types = [];
-  foreach ($result->facets[$facet_name]->terms as $term => $count) {
-    $types[drupal_strtolower($term)] = $count;
-  }
-
-  return $types;
+  // Terms is a map from term names to result frequencies.
+  $term_names = array_keys($result->facets[$facet_name]->terms);
+  return array_map('drupal_strtolower', $term_names);
 }
 
 /**

--- a/modules/opensearch/includes/opensearch.search.inc
+++ b/modules/opensearch/includes/opensearch.search.inc
@@ -43,6 +43,29 @@ function opensearch_search_material_types() {
 }
 
 /**
+ * Get a list of sources from OpenSearch
+ */
+function opensearch_search_sources() {
+  // Get a list of sources by executing a null query and look at the facets
+  // result.
+  $options = array(
+    'facets' => array('facet.acSource'),
+    'numFacets' => 99,
+    'reply_only' => TRUE,
+    // 'sort' => 'random',
+  );
+  module_load_include('client.inc', 'opensearch');
+  $result = opensearch_do_search("*", 0, 0, $options);
+
+  $sources = array();
+  foreach ($result->facets['facet.acSource']->terms as $term => $count) {
+    $sources[drupal_strtolower($term)] = $count;
+  }
+
+  return $sources;
+}
+
+/**
  * Load objects from Open Search.
  *
  * @param string[] $ids

--- a/modules/opensearch/includes/opensearch.search.inc
+++ b/modules/opensearch/includes/opensearch.search.inc
@@ -19,50 +19,46 @@ use Ting\Search\TingSearchSort;
  * Get a list of material types from the Well.
  */
 function opensearch_search_material_types() {
-  // Ensure we have ting client.
-  module_load_include('inc', 'opensearch', 'opensearch.client');
-
-  // Get a list of types by executing a null query and look at the facets
-  // result.
-  $options = [
-    'facets' => ['facet.type'],
-    'numFacets' => 99,
-    'reply_only' => TRUE,
-    // Following configuration breaks the search, commented out for now.
-    // 'sort' => 'random',
-  ];
-  module_load_include('client.inc', 'opensearch');
-  $result = opensearch_do_search("*", 0, 0, $options);
-
-  $types = [];
-  foreach ($result->facets['facet.type']->terms as $term => $count) {
-    $types[drupal_strtolower($term)] = $count;
-  }
-
-  return $types;
+  return _opensearch_get_facet_values('facet.type');
 }
 
 /**
  * Get a list of sources from OpenSearch
  */
 function opensearch_search_sources() {
-  // Get a list of sources by executing a null query and look at the facets
+  return _opensearch_get_facet_values('facet.acSource');
+}
+
+/**
+ * Gets possible values for a facet from OpenSearch.
+ *
+ * @param string $facet_name
+ *   The name of the facet.
+ *
+ * @return array
+ *   A map from facet names to number of results matching that facet.
+ */
+function _opensearch_get_facet_values($facet_name) {
+  // Ensure we have ting client.
+  module_load_include('inc', 'opensearch', 'opensearch.client');
+
+  // Get a list of types by executing a null query and look at the facets
   // result.
-  $options = array(
-    'facets' => array('facet.acSource'),
+  $options = [
+    'facets' => [$facet_name],
     'numFacets' => 99,
     'reply_only' => TRUE,
+    // Following configuration breaks the search, commented out for now.
     // 'sort' => 'random',
-  );
-  module_load_include('client.inc', 'opensearch');
+  ];
   $result = opensearch_do_search("*", 0, 0, $options);
 
-  $sources = array();
-  foreach ($result->facets['facet.acSource']->terms as $term => $count) {
-    $sources[drupal_strtolower($term)] = $count;
+  $types = [];
+  foreach ($result->facets[$facet_name]->terms as $term => $count) {
+    $types[drupal_strtolower($term)] = $count;
   }
 
-  return $sources;
+  return $types;
 }
 
 /**

--- a/modules/p2/ding_serendipity_ting_entity/ding_serendipity_ting_entity.module
+++ b/modules/p2/ding_serendipity_ting_entity/ding_serendipity_ting_entity.module
@@ -80,7 +80,7 @@ function ding_serendipity_ting_entity_adhl_settings() {
   $form['ding_serendipity_ting_entity_adhl_accepted_types'] = array(
     '#type' => 'checkboxes',
     '#title' => t('Select which types are looked up for ADHL'),
-    '#options' => drupal_map_assoc(array_keys($types)),
+    '#options' => drupal_map_assoc($types),
     '#default_value' => variable_get('ding_serendipity_ting_entity_adhl_accepted_types', array()),
   );
 

--- a/modules/ting/ting.admin.inc
+++ b/modules/ting/ting.admin.inc
@@ -184,14 +184,14 @@ function ting_admin_reservable_settings($form_state) {
   $form['ting_reservable']['ting_reservable_sources'] = array(
     '#type' => 'checkboxes',
     '#title' => t('Sources'),
-    '#options' => drupal_map_assoc(array_keys($sources)),
+    '#options' => drupal_map_assoc($sources),
     '#default_value' => variable_get('ting_reservable_sources', _ting_default_reservable_sources()),
   );
 
   $form['ting_reservable']['ting_reservable_types'] = array(
     '#type' => 'checkboxes',
     '#title' => t('Types'),
-    '#options' => drupal_map_assoc(array_keys($types)),
+    '#options' => drupal_map_assoc($types),
     '#default_value' => variable_get('ting_reservable_types', _ting_default_reservable_types()),
   );
   // Save us the trouble of running array_filter.

--- a/modules/ting/ting.install
+++ b/modules/ting/ting.install
@@ -271,3 +271,18 @@ function ting_update_7010() {
 function ting_update_7011() {
   variable_del('ting_filter_by_local_holdings');
 }
+
+/**
+ * Convert material types and sources to new structure.
+ */
+function ting_update_7012() {
+  // Variables currently contain maps of names to frequencies. Going forward
+  // we only require the names so convert each to an array of names.
+  $var_names = array('ting_well_types', 'ting_well_sources');
+  array_map(function($var_name) {
+    $var_value = variable_get($var_name, []);
+    if (!empty($var_value)) {
+      variable_set($var_name, array_keys($var_value));
+    }
+  }, $var_names);
+}

--- a/modules/ting/ting.module
+++ b/modules/ting/ting.module
@@ -843,24 +843,14 @@ function _ting_fetch_well_types() {
  *   Array with the sources.
  */
 function _ting_fetch_well_sources() {
-  // Get a list of sources by executing a null query and look at the facets
-  // result.
-  // TODO BBS-SAL: Port as provider call.
-  $options = array(
-    'facets' => array('facet.acSource'),
-    'numFacets' => 99,
-    'reply_only' => TRUE,
-    // 'sort' => 'random',
-  );
-  module_load_include('client.inc', 'opensearch');
-  $result = opensearch_do_search("*", 0, 0, $options);
-
   $sources = array();
-  foreach ($result->facets['facet.acSource']->terms as $term => $count) {
-    $sources[drupal_strtolower($term)] = $count;
+
+  // Delegate the fetching of sources to a search provider.
+  if (ding_provider_implements('search', 'sources')) {
+    $sources = ding_provider_invoke('search', 'sources');
   }
 
-  // Only save if we actually got any types.
+  // Only save if we actually got any sources.
   if (!empty($sources)) {
     variable_set('ting_well_sources', $sources);
   }


### PR DESCRIPTION
This allows providers to supply a list of known sources for objects
and collections.

This PR replaces the current implementation of source retrieval with a
Provider call search_sources and moves the implementation to the 
opensearch module.

We also provide an implementation of the provider call in the
connie_search module and a test.

BBS-161