### PR TITLE
Further simplification of SAL filters and a new exception

### DIFF
--- a/modules/opensearch/opensearch_unit.test
+++ b/modules/opensearch/opensearch_unit.test
@@ -41,7 +41,7 @@ class OpensearchUnitTest extends DingUnitTestBase {
   public function testStatementGroupRenderer() {
     // The final query-string the arrangement of groupings and fields below
     // should end up as. Notice that we use mapped fields.
-    $expected_result = '(test_author="1" AND test_subject="2") OR test_category="3\"" OR ((test_language OR test_author="5") AND (test_subject="6" OR test_category="7"))';
+    $expected_result = '(test_author="1" AND test_subject="2") OR test_category="3\"" OR (test_language="4" OR test_author="5") OR (test_subject="6" OR test_category="7")';
 
     // Build the query, use the common names that will have to be mapped in
     // order to match the expected output.
@@ -54,24 +54,21 @@ class OpensearchUnitTest extends DingUnitTestBase {
     // Standalone field.
     $field2 = new TingSearchFieldFilter(TingSearchCommonFields::CATEGORY, '3"');
 
-    // Group 4 (an OR group) is nested inside group 3 so we define it first.
-    $group4 = new BooleanStatementGroup([
+    // Group 4 (an OR group).
+    $group3 = new BooleanStatementGroup([
       // Test boolean field behaviour (that is: this field should be rendered
       // without the comparison).
-      new TingSearchFieldFilter(TingSearchCommonFields::LANGUAGE),
-      new TingSearchFieldFilter(TingSearchCommonFields::AUTHOR, 5)
+      new TingSearchFieldFilter(TingSearchCommonFields::LANGUAGE, 4),
+      new TingSearchFieldFilter(TingSearchCommonFields::AUTHOR, 5),
     ], BooleanStatementInterface::OP_OR);
 
-    // Group 5 (an AND group) is nested inside group 3 so we define it first.
-    $group5 = new BooleanStatementGroup([
+    // Group 5 (an AND group).
+    $group4 = new BooleanStatementGroup([
       new TingSearchFieldFilter(TingSearchCommonFields::SUBJECT, 6),
       new TingSearchFieldFilter(TingSearchCommonFields::CATEGORY, 7),
     ], BooleanStatementInterface::OP_OR);
 
-    // Join group 4 and 5 together with an AND group.
-    $group3 = new BooleanStatementGroup([$group4, $group5], BooleanStatementInterface::OP_AND);
-
-    $groups = [$group1, $field2, $group3];
+    $groups = [$group1, $field2, $group3, $group4];
 
     // Setup a renderer configured to use our own mapping of fields.
     $strategy_double = $this->prophet->prophesize(TingSearchStrategyInterface::class);
@@ -86,7 +83,7 @@ class OpensearchUnitTest extends DingUnitTestBase {
 
     $renderer = new OpenSearchStatementGroupRender($strategy);
 
-    // Test that adding a single group around a list does not affect redering.
+    // Test that adding a single group around a list does not affect rendering.
     $filter_string_wrapped = $renderer->renderGroup((new BooleanStatementGroup($groups, BooleanStatementInterface::OP_OR)));
     $filter_string_from_list = $renderer->renderStatements($groups, BooleanStatementInterface::OP_OR);
     $this->assertEqual($filter_string_from_list, $filter_string_wrapped, "List of filters is rendered the same way as a list wrapped in a group.");

--- a/modules/opensearch/src/OpenSearchStatementGroupRender.php
+++ b/modules/opensearch/src/OpenSearchStatementGroupRender.php
@@ -173,12 +173,6 @@ class OpenSearchStatementGroupRender {
       $field_name = $field->getName();
     }
 
-    if ($field->isBoolean()) {
-      // Just render the field, it can be evaluated without the operator and
-      // value.
-      return $field_name;
-    }
-
     // Very simpel quotes. Enclose everything in double-quotes, and escape any
     // double-quotes in the value.
     $quoted_field = '"' . str_replace('"', '\"', $field->getValue()) . '"';

--- a/modules/ting/src/Search/BooleanStatementGroup.php
+++ b/modules/ting/src/Search/BooleanStatementGroup.php
@@ -1,33 +1,24 @@
 <?php
-/**
- * @file
- * The BooleanStatementGroup class
- */
 
-/**
- * Groups one or more boolean statements together. The statements are joined by
- * a boolean operator.
- */
 namespace Ting\Search;
 
 /**
- * Class BooleanStatementGroup
+ * Groups one or more boolean statements together.
  *
- * Joins multiple logic statements into a group.
- *
- * @package Ting\Search
+ * The statements are joined by a boolean operator.
  */
 class BooleanStatementGroup implements BooleanStatementInterface {
 
   /**
    * The grouped statements.
    *
-   * @var mixed[]
+   * @var TingSearchFieldFilter[]
    */
   protected $statements = [];
 
   /**
    * The operator to use if this group comes after another.
+   *
    * @var string
    */
   protected $logicOperator;
@@ -38,14 +29,17 @@ class BooleanStatementGroup implements BooleanStatementInterface {
    * The statements is one or more groups or fields and will be joined together
    * in a single group via the $logic_operator operator.
    *
-   * @param mixed[] $statements
-   *   Instances of \Ting\Search\BooleanStatementGroup and
-   *   \Ting\Search\TingSearchFieldFilter
-   *
+   * @param TingSearchFieldFilter[] $statements
+   *   One or more instances of \Ting\Search\TingSearchFieldFilter.
    * @param string $logic_operator
    *   A TingSearchBooleanStatementInterface::OP_* operation.
    */
   public function __construct(array $statements, $logic_operator = BooleanStatementInterface::OP_AND) {
+    // Let callers of getStatements() rely on getting at least one statement.
+    if (empty($statements)) {
+      throw new \InvalidArgumentException("Group must contain at least one statement.");
+    }
+
     $this->add($statements);
     $this->logicOperator = $logic_operator;
   }
@@ -70,9 +64,8 @@ class BooleanStatementGroup implements BooleanStatementInterface {
   /**
    * The grouped statements.
    *
-   * @return mixed[]
-   *   The statements, instances of BooleanStatementGroup and
-   *   TingSearchFieldFilter.
+   * @return TingSearchFieldFilter[]
+   *   One or more instances of TingSearchFieldFilter.
    */
   public function getStatements() {
     return $this->statements;
@@ -81,23 +74,14 @@ class BooleanStatementGroup implements BooleanStatementInterface {
   /**
    * Add a statement to the group.
    *
-   * @param mixed[] $statements
-   *   One or more implementations of \Ting\Search\BooleanStatementGroup and
-   *   \Ting\Search\TingSearchFieldFilter.
+   * @param mixed $statements
+   *   One or more implementations \Ting\Search\TingSearchFieldFilter.
    */
   public function add($statements) {
     if (!is_array($statements)) {
       $statements = [$statements];
     }
-    foreach ($statements as $statement) {
-      if ($statement instanceof self || $statement instanceof TingSearchFieldFilter) {
-        $this->statements[] = $statement;
-      }
-      else {
-        throw new \InvalidArgumentException(
-          "Unsupported type, only BooleanStatementInterface and TingSearchFieldFilter is supported"
-        );
-      }
-    }
+    $this->statements = $statements;
   }
+
 }

--- a/modules/ting/src/Search/DingProviderStrategy.php
+++ b/modules/ting/src/Search/DingProviderStrategy.php
@@ -28,6 +28,10 @@ class DingProviderStrategy implements TingSearchStrategyInterface {
     try {
       return ding_provider_invoke('search', 'search', $query);
     }
+    catch (UnsupportedSearchQueryException $e) {
+      watchdog_exception('ting', $e, 'The provider did not support the query');
+      return new NullSearchResult($query);
+    }
     catch (SearchProviderException $e) {
       watchdog_exception('ting', $e, 'Error while searching');
       return new NullSearchResult($query);

--- a/modules/ting/src/Search/TingSearchFieldFilter.php
+++ b/modules/ting/src/Search/TingSearchFieldFilter.php
@@ -1,13 +1,9 @@
 <?php
-/**
- * @file
- * The TingSearchFieldFilter class.
- */
 
 namespace Ting\Search;
 
 /**
- * Class TingSearchFieldFilter
+ * Class TingSearchFieldFilter.
  *
  * Represents a provider-independent comparison between a field instance and a
  * value using an operator.
@@ -15,8 +11,6 @@ namespace Ting\Search;
  * @package Ting\Search
  */
 class TingSearchFieldFilter {
-
-  const BOOLEAN_FIELD_VALUE = self::class . '-MISSING-VALUE';
 
   /**
    * The field.
@@ -28,9 +22,7 @@ class TingSearchFieldFilter {
   /**
    * Field value.
    *
-   * If TingSearchFieldFilter::BOOLEAN_FIELD_VALUE the field is a boolean field.
-   *
-   * @var mixed|TingSearchFieldFilter::BOOLEAN_FIELD_VALUE
+   * @var mixed
    */
   protected $value;
 
@@ -39,14 +31,10 @@ class TingSearchFieldFilter {
    *
    * @param string $name
    *   The field name.
-   *
-   * @param mixed|TingSearchFieldFilter::BOOLEAN_FIELD_VALUE $value
-   *   Expected field-value, if omitted or set to
-   *   TingSearchFieldFilter::BOOLEAN_FIELD_VALUE the field is treated as a
-   *   boolean field that will be compared without an operator Eg:
-   *   (myboolfield AND anotherfield=123)
+   * @param mixed $value
+   *   Expected field-value.
    */
-  public function __construct($name, $value = self::BOOLEAN_FIELD_VALUE) {
+  public function __construct($name, $value) {
     $this->name = $name;
     $this->value = $value;
   }
@@ -71,14 +59,4 @@ class TingSearchFieldFilter {
     return $this->value;
   }
 
-  /**
-   * Whether this field can be evaluated by itself.
-   *
-   * @return bool
-   *   TRUE if the field is boolean, FALSE if the operator and value is
-   *   necessary to evaluate the field.
-   */
-  public function isBoolean() {
-    return $this->getValue() === TingSearchFieldFilter::BOOLEAN_FIELD_VALUE;
-  }
 }

--- a/modules/ting/src/Search/TingSearchRequest.php
+++ b/modules/ting/src/Search/TingSearchRequest.php
@@ -491,18 +491,15 @@ class TingSearchRequest {
    *
    * @param string $name
    *   The field name.
-   *
-   * @param mixed|TingSearchFieldFilter::BOOLEAN_FIELD_VALUE $value
-   *   Expected field-value, if omitted or set to
-   *   TingSearchFieldFilter::BOOLEAN_FIELD_VALUE the field is treated as a
-   *   boolean field that will be compared without an operator Eg:
-   *   (myboolfield AND anotherfield=123)
+   * @param mixed $value
+   *   Expected field-value.
    *
    * @return TingSearchRequest
    *   the current query object.
    */
-  public function addFieldFilter($name, $value = TingSearchFieldFilter::BOOLEAN_FIELD_VALUE) {
+  public function addFieldFilter($name, $value) {
     $this->addFieldFilters([new TingSearchFieldFilter($name, $value)]);
     return $this;
   }
+
 }

--- a/modules/ting/src/Search/UnsupportedSearchQueryException.php
+++ b/modules/ting/src/Search/UnsupportedSearchQueryException.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * @file
+ * The UnsupportedSearchQueryException class.
+ */
+
+namespace Ting\Search;
+
+/**
+ * Thrown when a search-provider detects an unsupported query.
+ *
+ * Eg. If a provider does not support joining statements involving multiple
+ * fields with OR, it can throw this exception if such a query is encountered.
+ */
+class UnsupportedSearchQueryException extends SearchProviderException {
+
+}


### PR DESCRIPTION
- Removed support for nested groups (was not used)
- Removed support for boolean fields (was not used)
- Added an exception the provider can use when a query it does not support is encountered

BBS-171 and BBS-193