### PR TITLE
BBS-160: Material type handling

### DIFF
--- a/modules/primo/includes/primo.search.inc
+++ b/modules/primo/includes/primo.search.inc
@@ -12,8 +12,6 @@ use Primo\Ting\Result;
 use Ting\Search\SearchProviderException;
 use Ting\Search\TingSearchRequest;
 
-define('PRIMO_FACET_MATERIAL_TYPE', 'rtype');
-
 // TODO Remove this once Primo search provider is fully implemented.
 // Ding does not support mixing multiple partial implementations of a provider
 // so we fall back to OpenSearch while we implement Primo. Thus we need to
@@ -26,19 +24,11 @@ module_load_include('inc', 'opensearch',
  * Get a list of material types from Primo.
  */
 function primo_search_material_types() {
-  $result = primo_client()->search('any,contains,a', 1, 1);
-  $facet = $result->getFacet(PRIMO_FACET_MATERIAL_TYPE);
-  if (!empty($facet)) {
-    return array_keys($facet->getValues());
-  } else {
-    watchdog(
-      'primo',
-      'Unable to extract material type facet %facet from result',
-      ['%facet' => PRIMO_FACET_MATERIAL_TYPE],
-      WATCHDOG_WARNING
-    );
-    return [];
-  }
+  // We cannot retrieve patron-friendly list of material types directy from
+  // Primo. Instead we rely on an managed map from Primo material type ids to
+  // material type names. Returning the values means returning the names as
+  // expected by this hook implementation.
+  return array_values(variable_get('primo_material_type_map', []));
 }
 
 /**

--- a/modules/primo/includes/primo.search.inc
+++ b/modules/primo/includes/primo.search.inc
@@ -12,6 +12,8 @@ use Primo\Ting\Result;
 use Ting\Search\SearchProviderException;
 use Ting\Search\TingSearchRequest;
 
+define('PRIMO_FACET_MATERIAL_TYPE', 'rtype');
+
 // TODO Remove this once Primo search provider is fully implemented.
 // Ding does not support mixing multiple partial implementations of a provider
 // so we fall back to OpenSearch while we implement Primo. Thus we need to
@@ -24,7 +26,19 @@ module_load_include('inc', 'opensearch',
  * Get a list of material types from Primo.
  */
 function primo_search_material_types() {
-  return opensearch_search_material_types();
+  $result = primo_client()->search('any,contains,a', 1, 1);
+  $facet = $result->getFacet(PRIMO_FACET_MATERIAL_TYPE);
+  if (!empty($facet)) {
+    return array_keys($facet->getValues());
+  } else {
+    watchdog(
+      'primo',
+      'Unable to extract material type facet %facet from result',
+      ['%facet' => PRIMO_FACET_MATERIAL_TYPE],
+      WATCHDOG_WARNING
+    );
+    return [];
+  }
 }
 
 /**

--- a/modules/primo/primo.admin.inc
+++ b/modules/primo/primo.admin.inc
@@ -1,6 +1,11 @@
 <?php
 
 /**
+ * @file
+ * Administration interface for the Primo module.
+ */
+
+/**
  * Setting form for Primo configuration.
  *
  * @return []
@@ -200,7 +205,7 @@ function _primo_textarea_value_map(array $element, $input = FALSE, $form_state =
  * This is basicly the reverse of _primo_textarea_value_map() and useful for
  * displaying a map strings in a textarea.
  *
- * @param mixed $array
+ * @param mixed $map
  *   Input value. Should be a map of strings.
  *
  * @return string
@@ -222,15 +227,15 @@ function _primo_textarea_map_value($map) {
  *
  * Use with #element_validate.
  *
- * @param $element
+ * @param array $element
  *   The form element. It is important that this is passed by reference so we
  *   can update the element value if validation fails.
- * @param $form_state
+ * @param array $form_state
  *   The form state.
- * @param $form
+ * @param array $form
  *   The form.
  */
-function _primo_textarea_map_validate(&$element, &$form_state, $form) {
+function _primo_textarea_map_validate(array &$element, array &$form_state, array $form) {
   foreach ($element['#value'] as $key => $value) {
     if (empty($value) || empty($key)) {
       form_error($element, t('Unable to extract mapping from element. Please ensure format is correct.'));

--- a/modules/primo/primo.admin.inc
+++ b/modules/primo/primo.admin.inc
@@ -97,6 +97,16 @@ function primo_code_mapping_form() {
     '#required' => TRUE,
   ];
 
+  $form['primo_genre_map'] = [
+    '#type' => 'textarea',
+    '#title' => t('Genres'),
+    '#default_value' => _primo_textarea_map_value(variable_get('primo_genre_map', [])),
+    '#value_callback' => '_primo_textarea_value_map',
+    '#element_validate' => ['_primo_textarea_map_validate'],
+    '#description' => t('Configure a mapping from Primo genre codes to descriptions that are understandable by a patron. Enter one mapping per line in the format "[primo code]|[patron text]" (without " and []).'),
+    '#required' => TRUE,
+  ];
+
   return system_settings_form($form);
 }
 

--- a/modules/primo/primo.admin.inc
+++ b/modules/primo/primo.admin.inc
@@ -1,0 +1,234 @@
+<?php
+
+/**
+ * Setting form for Primo configuration.
+ *
+ * @return []
+ *   A Form API array
+ */
+function primo_settings_form() {
+  $form = array();
+
+  $form['primo'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Primo service settings'),
+    '#tree' => FALSE,
+  );
+
+  $form['primo']['primo_base_url'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Base URL'),
+    '#description' => t('Base URL for Primo service.'),
+    '#required' => TRUE,
+    '#default_value' => variable_get('primo_base_url', ''),
+  );
+
+  $form['primo']['primo_institution_code'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Institution code'),
+    '#description' => t('Relevant for restricted scopes or for when searching against Primo Central.'),
+    '#required' => TRUE,
+    '#default_value' => variable_get('primo_institution_code', ''),
+  );
+
+  $form['primo']['primo_location_scopes'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Search scope'),
+    '#description' => t('List of institution codes the searches should be scoped within. The list must be comma-seperated without spaces and suitable for a local loc parameter. See <a href="@briefsearch-documentation">the Brief Search documentation</a>',
+      ['@briefsearch-documentation' => 'https://developers.exlibrisgroup.com/primo/apis/webservices/xservices/search/briefsearch']),
+    '#required' => FALSE,
+    '#default_value' => variable_get('primo_location_scopes', ''),
+  );
+
+  $form['primo']['primo_sourceid'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Source ID'),
+    '#description' => t('Used for creating record ID from source record ID.'),
+    '#required' => TRUE,
+    '#default_value' => variable_get('primo_sourceid', ''),
+  );
+
+  $form['primo']['primo_source_systems'] = array(
+    '#type' => 'textarea',
+    '#title' => t('Source systems'),
+    '#default_value' => _primo_textarea_array_value(variable_get('primo_source_systems', [])),
+    '#value_callback' => '_primo_textarea_value_array',
+    '#description' => t("System identifies the system used by the source repositories indexed by Primo. Examples: Aleph, ADAM, MetaLib, SFX, and Digitool).\nEnter one per line and note that spelling must be exactly as it appears in Primo."),
+    '#required' => TRUE,
+  );
+
+  $form['primo']['primo_enable_logging'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable logging'),
+    '#default_value' => variable_get('primo_enable_logging', FALSE),
+    '#description' => t('Logs requests to the Primo webservice.'),
+  );
+
+  $form['#submit'][] = 'primo_settings_form_submit';
+  return system_settings_form($form);
+}
+
+/**
+ * Submit handler for the primo provider settings form.
+ */
+function primo_settings_form_submit($form, &$form_state) {
+  // Do some basic whitespace cleanup in case the user was sloppy.
+  if (isset($form_state['values']['primo_location_scopes'])) {
+    $form_state['values']['primo_location_scopes'] = trim(str_replace(' ', '', $form_state['values']['primo_location_scopes']));
+  }
+}
+
+/**
+ * Form for configuring mapping between Primo codes and patron texts.
+ *
+ * @return mixed
+ *   A Form API array
+ */
+function primo_code_mapping_form() {
+  $form = [];
+
+  $form['primo_material_type_map'] = [
+    '#type' => 'textarea',
+    '#title' => t('Material types'),
+    '#default_value' => _primo_textarea_map_value(variable_get('primo_material_type_map', [])),
+    '#value_callback' => '_primo_textarea_value_map',
+    '#element_validate' => ['_primo_textarea_map_validate'],
+    '#description' => t('Configure a mapping from Primo material type codes to descriptions that are understandable by a patron. Enter one mapping per line in the format "[primo code]|[patron text]" (without " and []).'),
+    '#required' => TRUE,
+  ];
+
+  return system_settings_form($form);
+}
+
+/**
+ * Value callback for text area elements which represent arrays of strings.
+ *
+ * This callback is useful for textareas where the user is supposed to enter
+ * one value per line. The contents of the textarea is then mapped from a
+ * multiline string to an array of singleline strings.
+ *
+ * Use with #value_callback
+ *
+ * @param array $element
+ *   The form element.
+ * @param string|FALSE $input
+ *   The user input string. FALSE if there is no user input.
+ * @param array $form_state
+ *   The form state.
+ *
+ * @return string[]
+ *   Array of single-line strings.
+ */
+function _primo_textarea_value_array(array $element, $input = FALSE, $form_state = []) {
+  // Return any default value if no value is provided.
+  if ($input === FALSE) {
+    return isset($element['#default_value']) ? $element['#default_value'] : NULL;
+  }
+
+  // Split into multiple single-line strings and clean up whitespace.
+  $elements = explode("\n", $input);
+  return array_map('trim', $elements);
+}
+
+/**
+ * Converts an array of strings to a single multiline string.
+ *
+ * This is basicly the reverse of _primo_textarea_value_array() and useful for
+ * displaying an array of strings in a textarea.
+ *
+ * @param mixed $array
+ *   Input value. Should be an array of strings.
+ *
+ * @return string
+ *   A single multiline string.
+ */
+function _primo_textarea_array_value($array) {
+  return implode("\n", $array);
+}
+
+/**
+ * Value callback for text area elements which represent a map of strings.
+ *
+ * This callback is useful for textareas where the user is supposed to enter
+ * one mapping per line in the format [key]|[value]. The contents of the
+ * textarea is then mapped from a multiline string to a map.
+ *
+ * Use with #value_callback
+ *
+ * @param array $element
+ *   The form element.
+ * @param string|FALSE $input
+ *   The user input string. FALSE if there is no user input.
+ * @param array $form_state
+ *   The form state.
+ *
+ * @return string[]
+ *   Map of values.
+ */
+function _primo_textarea_value_map(array $element, $input = FALSE, $form_state = []) {
+  // Return any default value if no value is provided.
+  if ($input === FALSE) {
+    return isset($element['#default_value']) ? $element['#default_value'] : NULL;
+  }
+
+  // Convert the input to an array of singleline strings.
+  $array = _primo_textarea_value_array($element, $input, $form_state);
+
+  // Convert each array entry into an entry in the map.
+  $map = [];
+  array_walk($array, function($entry) use (&$map) {
+    list ($key, $value) = preg_split('/\s*\|\s*/', $entry, 2);
+    $map[$key] = $value;
+  });
+  return $map;
+}
+
+
+/**
+ * Converts an map strings to a single multiline string.
+ *
+ * This is basicly the reverse of _primo_textarea_value_map() and useful for
+ * displaying a map strings in a textarea.
+ *
+ * @param mixed $array
+ *   Input value. Should be a map of strings.
+ *
+ * @return string
+ *   A single multiline string.
+ */
+function _primo_textarea_map_value($map) {
+  // Convert the map into an array of strings.
+  $array = array_map(function($key, $value) {
+    return implode('|', [ $key, $value ]);
+  }, array_keys($map), $map);
+  // Convert the array into a single multiline string.
+  return _primo_textarea_array_value($array);
+}
+
+/**
+ * Validation callback for map elements.
+ *
+ * This should ensure that the contents of the element is in the correct format.
+ *
+ * Use with #element_validate.
+ *
+ * @param $element
+ *   The form element. It is important that this is passed by reference so we
+ *   can update the element value if validation fails.
+ * @param $form_state
+ *   The form state.
+ * @param $form
+ *   The form.
+ */
+function _primo_textarea_map_validate(&$element, &$form_state, $form) {
+  foreach ($element['#value'] as $key => $value) {
+    if (empty($value) || empty($key)) {
+      form_error($element, t('Unable to extract mapping from element. Please ensure format is correct.'));
+      // When raising an error we have to manually convert our map back to a
+      // value suitable for the element. For some reason this does not work with
+      // $form_state.
+      $element['#value'] = _primo_textarea_map_value($element['#value']);
+      break;
+    }
+  };
+}

--- a/modules/primo/primo.install
+++ b/modules/primo/primo.install
@@ -96,6 +96,7 @@ function primo_install() {
  */
 function primo_install_set_defaults() {
   primo_install_set_facet_defaults();
+  primo_install_set_material_type_defaults();
 }
 
 /**
@@ -145,6 +146,48 @@ function primo_install_set_facet_defaults() {
 }
 
 /**
+ * Setup default material type names.
+ */
+function primo_install_set_material_type_defaults() {
+  $material_type_map = [
+    'archeological_finds' => 'Archeological finds',
+    'articles' => 'Article',
+    'audiobooks' => 'Audiobook',
+    'book_chapters' => 'Book Chapter',
+    'books' => 'Book',
+    'cassette' => 'Cassette',
+    'coin' => 'Coin',
+    'compactdisk' => 'Audio disc',
+    'computerfiles' => 'Computer file',
+    'dissertations' => 'Dissertation',
+    'document' => 'Document',
+    'drawing' => 'Drawing',
+    'ebook' => 'Ebook',
+    'ethnology' => ' Ethnology - answer',
+    'house' => 'House',
+    'images' => 'Image',
+    'journals' => 'Journal',
+    'lprecord' => 'Audio record',
+    'manuscripts' => 'Manuscript',
+    'maps' => 'Map',
+    'mixedmaterial' => 'Mixed material',
+    'music' => 'Music',
+    'music_score' => 'Notated music',
+    'music_song' => 'Music - song',
+    'object' => 'Object',
+    'other' => 'Other',
+    'painting' => 'Painting',
+    'place_name' => 'Place name',
+    'ruin' => 'Ruin',
+    'tools' => 'Tools',
+    'visualmaterial' => 'Visual material',
+    'websites' => 'Website',
+  ];
+
+  variable_set('primo_material_type_map', $material_type_map);
+}
+
+/**
  * Add cache table to cache objects we generate from searches.
  */
 function primo_update_7001() {
@@ -158,5 +201,12 @@ function primo_update_7001() {
  * Set defaults for Primo.
  */
 function primo_update_7002() {
+  primo_install_set_defaults();
+}
+
+/**
+ * Update defaults for Primo.
+ */
+function primo_update_7003() {
   primo_install_set_defaults();
 }

--- a/modules/primo/primo.install
+++ b/modules/primo/primo.install
@@ -5,6 +5,68 @@
  * Main install file for Primo.
  */
 
+define('PRIMO_FACET_MATERIAL_TYPE', 'rtype');
+
+/**
+ * Implements hook_requirements().
+ */
+function primo_requirements($phase) {
+  if ($phase !== 'runtime') {
+    return [];
+  }
+
+  $t = get_t();
+
+  // Make sure we have our material types mapped.
+  $material_type_req = [ 'title' => 'Primo material types' ];
+
+  // Do a dummy search with the intent of returning as many results as possible.
+  // We are not really interested in the results but in the facets they cover.
+  $result = primo_client()->search([ 'query' => 'any,contains,a' ], 1, 1);
+  $facet = $result->getFacet(PRIMO_FACET_MATERIAL_TYPE);
+  if (!empty($facet)) {
+    $material_types = $facet->getValues();
+    $material_type_map = variable_get('primo_material_type_map', []);
+    $mapped_material_type_ids = array_intersect_key($material_types, $material_type_map);
+    $material_type_req += [
+      'value' => $t(
+        '%num_material_types mapped material types',
+        ['%num_material_types' => count($mapped_material_type_ids)]
+      )
+    ];
+
+    $unmapped_material_type_ids = array_diff_key($material_types, $material_type_map);
+    if (empty($unmapped_material_type_ids)) {
+      $material_type_req += [
+        'severity' => REQUIREMENT_OK
+      ];
+    }
+    else {
+      $material_type_req += [
+        'description' => $t('Material type codes %material_types do not have patron-friendly versions. Please <a href="@primo_map_url">map them</a>.',
+          [
+            '%material_types' => implode(', ', array_keys($unmapped_material_type_ids)),
+            '@primo_map_url' => url('admin/config/primo/mapping')
+          ]
+        ),
+        'severity' => REQUIREMENT_WARNING
+      ];
+    }
+  }
+  else {
+    $material_type_req += [
+      'description' => $t('Unable to extract material type facet %facet from search result.',
+        ['%facet' => PRIMO_FACET_MATERIAL_TYPE]
+      ),
+      'severity' => REQUIREMENT_ERROR
+    ];
+  }
+
+  return [
+    'primo_material_types' => $material_type_req,
+  ];
+}
+
 /**
  * Implements hook_schema().
  */

--- a/modules/primo/primo.install
+++ b/modules/primo/primo.install
@@ -6,6 +6,7 @@
  */
 
 define('PRIMO_FACET_MATERIAL_TYPE', 'rtype');
+define('PRIMO_FACET_GENRE', 'genre');
 
 /**
  * Implements hook_requirements().
@@ -17,12 +18,13 @@ function primo_requirements($phase) {
 
   $t = get_t();
 
-  // Make sure we have our material types mapped.
-  $material_type_req = [ 'title' => 'Primo material types' ];
-
   // Do a dummy search with the intent of returning as many results as possible.
   // We are not really interested in the results but in the facets they cover.
   $result = primo_client()->search([ 'query' => 'any,contains,a' ], 1, 1);
+
+  // Make sure we have our material types mapped.
+  $material_type_req = [ 'title' => 'Primo material types' ];
+
   $facet = $result->getFacet(PRIMO_FACET_MATERIAL_TYPE);
   if (!empty($facet)) {
     $material_types = $facet->getValues();
@@ -62,8 +64,51 @@ function primo_requirements($phase) {
     ];
   }
 
+  // Make sure we have our genres mapped.
+  $genre_req = [ 'title' => 'Primo genres' ];
+
+  $facet = $result->getFacet(PRIMO_FACET_GENRE);
+  if (!empty($facet)) {
+    $genres = $facet->getValues();
+    $genre_map = variable_get('primo_genre_map', []);
+    $mapped_genres_codes = array_intersect_key($genres, $genre_map);
+    $genre_req += [
+      'value' => $t(
+        '%num_material_types mapped genres',
+        ['%num_material_types' => count($mapped_genres_codes)]
+      )
+    ];
+
+    $unmapped_genre_codes = array_diff_key($genres, $genre_map);
+    if (empty($unmapped_genre_codes)) {
+      $genre_req += [
+        'severity' => REQUIREMENT_OK
+      ];
+    }
+    else {
+      $genre_req += [
+        'description' => $t('Genre codes %genre_codes do not have patron-friendly versions. Please <a href="@primo_map_url">map them</a>.',
+          [
+            '%genre_codes' => implode(', ', array_keys($unmapped_genre_codes)),
+            '@primo_map_url' => url('admin/config/primo/mapping')
+          ]
+        ),
+        'severity' => REQUIREMENT_WARNING
+      ];
+    }
+  }
+  else {
+    $genre_req += [
+      'description' => $t('Unable to extract genre facet %facet from search result.',
+        ['%facet' => PRIMO_FACET_GENRE]
+      ),
+      'severity' => REQUIREMENT_ERROR
+    ];
+  }
+
   return [
     'primo_material_types' => $material_type_req,
+    'primo_genres' => $genre_req,
   ];
 }
 
@@ -97,6 +142,7 @@ function primo_install() {
 function primo_install_set_defaults() {
   primo_install_set_facet_defaults();
   primo_install_set_material_type_defaults();
+  primo_install_set_genre_defaults();
 }
 
 /**
@@ -185,6 +231,23 @@ function primo_install_set_material_type_defaults() {
   ];
 
   variable_set('primo_material_type_map', $material_type_map);
+}
+
+
+/**
+ * Setup default genre names.
+ */
+function primo_install_set_genre_defaults() {
+  $material_type_map = [
+    'drama' => 'Drama',
+    'juvenile_material' => 'Juvenile material',
+    'fiction' => 'Fiction',
+    'short_stories' => 'Short stories',
+    'biography' => 'Biography',
+    'poetry' => 'Poetry',
+  ];
+
+  variable_set('primo_genre_map', $material_type_map);
 }
 
 /**

--- a/modules/primo/primo.module
+++ b/modules/primo/primo.module
@@ -64,7 +64,7 @@ function primo_menu() {
     'page arguments' => array('primo_settings_form'),
     'access arguments' => array('administer primo settings'),
     'file' => 'primo.admin.inc',
-    'weight' => -1
+    'weight' => -1,
   );
 
   $items['admin/config/primo/mapping'] = array(

--- a/modules/primo/primo.module
+++ b/modules/primo/primo.module
@@ -230,7 +230,7 @@ function _primo_textarea_value_array(array $element, $input = FALSE, $form_state
 }
 
 /**
- * Converts an a array of strings to a single multiline array.
+ * Converts an array of strings to a single multiline string.
  *
  * This is basicly the reverse of _primo_textarea_value_array() and useful for
  * displaying an array of strings in a textarea.

--- a/modules/primo/primo.module
+++ b/modules/primo/primo.module
@@ -63,6 +63,7 @@ function primo_menu() {
     'page callback' => 'drupal_get_form',
     'page arguments' => array('primo_settings_form'),
     'access arguments' => array('administer primo settings'),
+    'file' => 'primo.admin.inc',
     'weight' => -1
   );
 
@@ -72,6 +73,7 @@ function primo_menu() {
     'page callback' => 'drupal_get_form',
     'page arguments' => array('primo_code_mapping_form'),
     'access arguments' => array('administer primo settings'),
+    'file' => 'primo.admin.inc',
   );
 
   // We also provide a cover implementation. Add a shortcut to the settings form
@@ -82,6 +84,7 @@ function primo_menu() {
     'page callback' => 'drupal_get_form',
     'page arguments' => array('primo_settings_form'),
     'access arguments' => array('administer site configuration'),
+    'file' => 'primo.admin.inc',
     'type' => MENU_LOCAL_TASK,
   );
 
@@ -97,239 +100,6 @@ function primo_permission() {
       'title' => t('Administer Primo settings'),
     ),
   );
-}
-
-/**
- * Setting form for Primo configuration.
- *
- * @return []
- *   A Form API array
- */
-function primo_settings_form() {
-  $form = array();
-
-  $form['primo'] = array(
-    '#type' => 'fieldset',
-    '#title' => t('Primo service settings'),
-    '#tree' => FALSE,
-  );
-
-  $form['primo']['primo_base_url'] = array(
-    '#type' => 'textfield',
-    '#title' => t('Base URL'),
-    '#description' => t('Base URL for Primo service.'),
-    '#required' => TRUE,
-    '#default_value' => variable_get('primo_base_url', ''),
-  );
-
-  $form['primo']['primo_institution_code'] = array(
-    '#type' => 'textfield',
-    '#title' => t('Institution code'),
-    '#description' => t('Relevant for restricted scopes or for when searching against Primo Central.'),
-    '#required' => TRUE,
-    '#default_value' => variable_get('primo_institution_code', ''),
-  );
-
-  $form['primo']['primo_location_scopes'] = array(
-    '#type' => 'textfield',
-    '#title' => t('Search scope'),
-    '#description' => t('List of institution codes the searches should be scoped within. The list must be comma-seperated without spaces and suitable for a local loc parameter. See <a href="@briefsearch-documentation">the Brief Search documentation</a>',
-      ['@briefsearch-documentation' => 'https://developers.exlibrisgroup.com/primo/apis/webservices/xservices/search/briefsearch']),
-    '#required' => FALSE,
-    '#default_value' => variable_get('primo_location_scopes', ''),
-  );
-
-  $form['primo']['primo_sourceid'] = array(
-    '#type' => 'textfield',
-    '#title' => t('Source ID'),
-    '#description' => t('Used for creating record ID from source record ID.'),
-    '#required' => TRUE,
-    '#default_value' => variable_get('primo_sourceid', ''),
-  );
-
-  $form['primo']['primo_source_systems'] = array(
-    '#type' => 'textarea',
-    '#title' => t('Source systems'),
-    '#default_value' => _primo_textarea_array_value(variable_get('primo_source_systems', [])),
-    '#value_callback' => '_primo_textarea_value_array',
-    '#description' => t("System identifies the system used by the source repositories indexed by Primo. Examples: Aleph, ADAM, MetaLib, SFX, and Digitool).\nEnter one per line and note that spelling must be exactly as it appears in Primo."),
-    '#required' => TRUE,
-  );
-
-  $form['primo']['primo_enable_logging'] = array(
-    '#type' => 'checkbox',
-    '#title' => t('Enable logging'),
-    '#default_value' => variable_get('primo_enable_logging', FALSE),
-    '#description' => t('Logs requests to the Primo webservice.'),
-  );
-
-  $form['#submit'][] = 'primo_settings_form_submit';
-  return system_settings_form($form);
-}
-
-/**
- * Submit handler for the primo provider settings form.
- */
-function primo_settings_form_submit($form, &$form_state) {
-  // Do some basic whitespace cleanup in case the user was sloppy.
-  if (isset($form_state['values']['primo_location_scopes'])) {
-    $form_state['values']['primo_location_scopes'] = trim(str_replace(' ', '', $form_state['values']['primo_location_scopes']));
-  }
-}
-
-/**
- * Form for configuring mapping between Primo codes and patron texts.
- *
- * @return mixed
- *   A Form API array
- */
-function primo_code_mapping_form() {
-  $form = [];
-
-  $form['primo_material_type_map'] = [
-    '#type' => 'textarea',
-    '#title' => t('Material types'),
-    '#default_value' => _primo_textarea_map_value(variable_get('primo_material_type_map', [])),
-    '#value_callback' => '_primo_textarea_value_map',
-    '#element_validate' => ['_primo_textarea_map_validate'],
-    '#description' => t('Configure a mapping from Primo material type codes to descriptions that are understandable by a patron. Enter one mapping per line in the format "[primo code]|[patron text]" (without " and []).'),
-    '#required' => TRUE,
-  ];
-
-  return system_settings_form($form);
-}
-
-/**
- * Value callback for text area elements which represent arrays of strings.
- *
- * This callback is useful for textareas where the user is supposed to enter
- * one value per line. The contents of the textarea is then mapped from a
- * multiline string to an array of singleline strings.
- *
- * Use with #value_callback
- *
- * @param array $element
- *   The form element.
- * @param string|FALSE $input
- *   The user input string. FALSE if there is no user input.
- * @param array $form_state
- *   The form state.
- *
- * @return string[]
- *   Array of single-line strings.
- */
-function _primo_textarea_value_array(array $element, $input = FALSE, $form_state = []) {
-  // Return any default value if no value is provided.
-  if ($input === FALSE) {
-    return isset($element['#default_value']) ? $element['#default_value'] : NULL;
-  }
-
-  // Split into multiple single-line strings and clean up whitespace.
-  $elements = explode("\n", $input);
-  return array_map('trim', $elements);
-}
-
-/**
- * Converts an array of strings to a single multiline string.
- *
- * This is basicly the reverse of _primo_textarea_value_array() and useful for
- * displaying an array of strings in a textarea.
- *
- * @param mixed $array
- *   Input value. Should be an array of strings.
- *
- * @return string
- *   A single multiline string.
- */
-function _primo_textarea_array_value($array) {
-  return implode("\n", $array);
-}
-
-/**
- * Value callback for text area elements which represent a map of strings.
- *
- * This callback is useful for textareas where the user is supposed to enter
- * one mapping per line in the format [key]|[value]. The contents of the
- * textarea is then mapped from a multiline string to a map.
- *
- * Use with #value_callback
- *
- * @param array $element
- *   The form element.
- * @param string|FALSE $input
- *   The user input string. FALSE if there is no user input.
- * @param array $form_state
- *   The form state.
- *
- * @return string[]
- *   Map of values.
- */
-function _primo_textarea_value_map(array $element, $input = FALSE, $form_state = []) {
-  // Return any default value if no value is provided.
-  if ($input === FALSE) {
-    return isset($element['#default_value']) ? $element['#default_value'] : NULL;
-  }
-
-  // Convert the input to an array of singleline strings.
-  $array = _primo_textarea_value_array($element, $input, $form_state);
-
-  // Convert each array entry into an entry in the map.
-  $map = [];
-  array_walk($array, function($entry) use (&$map) {
-    list ($key, $value) = preg_split('/\s*\|\s*/', $entry, 2);
-    $map[$key] = $value;
-  });
-  return $map;
-}
-
-
-/**
- * Converts an map strings to a single multiline string.
- *
- * This is basicly the reverse of _primo_textarea_value_map() and useful for
- * displaying a map strings in a textarea.
- *
- * @param mixed $array
- *   Input value. Should be a map of strings.
- *
- * @return string
- *   A single multiline string.
- */
-function _primo_textarea_map_value($map) {
-  // Convert the map into an array of strings.
-  $array = array_map(function($key, $value) {
-    return implode('|', [ $key, $value ]);
-  }, array_keys($map), $map);
-  // Convert the array into a single multiline string.
-  return _primo_textarea_array_value($array);
-}
-
-/**
- * Validation callback for map elements.
- *
- * This should ensure that the contents of the element is in the correct format.
- *
- * Use with #element_validate.
- *
- * @param $element
- *   The form element. It is important that this is passed by reference so we
- *   can update the element value if validation fails.
- * @param $form_state
- *   The form state.
- * @param $form
- *   The form.
- */
-function _primo_textarea_map_validate(&$element, &$form_state, $form) {
-  foreach ($element['#value'] as $key => $value) {
-    if (empty($value) || empty($key)) {
-      form_error($element, t('Unable to extract mapping from element. Please ensure format is correct.'));
-      // When raising an error we have to manually convert our map back to a
-      // value suitable for the element. For some reason this does not work with
-      // $form_state.
-      $element['#value'] = _primo_textarea_map_value($element['#value']);
-      break;
-    }
-  };
 }
 
 /**

--- a/modules/primo/primo.module
+++ b/modules/primo/primo.module
@@ -66,6 +66,14 @@ function primo_menu() {
     'weight' => -1
   );
 
+  $items['admin/config/primo/mapping'] = array(
+    'title' => 'Code mapping',
+    'description' => 'Configure mapping between Primo codes and end-user text',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('primo_code_mapping_form'),
+    'access arguments' => array('administer primo settings'),
+  );
+
   // We also provide a cover implementation. Add a shortcut to the settings form
   // under the cover settings as well.
   $items['admin/config/ting/covers/primo'] = array(
@@ -170,6 +178,28 @@ function primo_settings_form_submit($form, &$form_state) {
 }
 
 /**
+ * Form for configuring mapping between Primo codes and patron texts.
+ *
+ * @return mixed
+ *   A Form API array
+ */
+function primo_code_mapping_form() {
+  $form = [];
+
+  $form['primo_material_type_map'] = [
+    '#type' => 'textarea',
+    '#title' => t('Material types'),
+    '#default_value' => _primo_textarea_map_value(variable_get('primo_material_type_map', [])),
+    '#value_callback' => '_primo_textarea_value_map',
+    '#element_validate' => ['_primo_textarea_map_validate'],
+    '#description' => t('Configure a mapping from Primo material type codes to descriptions that are understandable by a patron. Enter one mapping per line in the format "[primo code]|[patron text]" (without " and []).'),
+    '#required' => TRUE,
+  ];
+
+  return system_settings_form($form);
+}
+
+/**
  * Value callback for text area elements which represent arrays of strings.
  *
  * This callback is useful for textareas where the user is supposed to enter
@@ -213,6 +243,93 @@ function _primo_textarea_value_array(array $element, $input = FALSE, $form_state
  */
 function _primo_textarea_array_value($array) {
   return implode("\n", $array);
+}
+
+/**
+ * Value callback for text area elements which represent a map of strings.
+ *
+ * This callback is useful for textareas where the user is supposed to enter
+ * one mapping per line in the format [key]|[value]. The contents of the
+ * textarea is then mapped from a multiline string to a map.
+ *
+ * Use with #value_callback
+ *
+ * @param array $element
+ *   The form element.
+ * @param string|FALSE $input
+ *   The user input string. FALSE if there is no user input.
+ * @param array $form_state
+ *   The form state.
+ *
+ * @return string[]
+ *   Map of values.
+ */
+function _primo_textarea_value_map(array $element, $input = FALSE, $form_state = []) {
+  // Return any default value if no value is provided.
+  if ($input === FALSE) {
+    return isset($element['#default_value']) ? $element['#default_value'] : NULL;
+  }
+
+  // Convert the input to an array of singleline strings.
+  $array = _primo_textarea_value_array($element, $input, $form_state);
+
+  // Convert each array entry into an entry in the map.
+  $map = [];
+  array_walk($array, function($entry) use (&$map) {
+    list ($key, $value) = preg_split('/\s*\|\s*/', $entry, 2);
+    $map[$key] = $value;
+  });
+  return $map;
+}
+
+
+/**
+ * Converts an map strings to a single multiline string.
+ *
+ * This is basicly the reverse of _primo_textarea_value_map() and useful for
+ * displaying a map strings in a textarea.
+ *
+ * @param mixed $array
+ *   Input value. Should be a map of strings.
+ *
+ * @return string
+ *   A single multiline string.
+ */
+function _primo_textarea_map_value($map) {
+  // Convert the map into an array of strings.
+  $array = array_map(function($key, $value) {
+    return implode('|', [ $key, $value ]);
+  }, array_keys($map), $map);
+  // Convert the array into a single multiline string.
+  return _primo_textarea_array_value($array);
+}
+
+/**
+ * Validation callback for map elements.
+ *
+ * This should ensure that the contents of the element is in the correct format.
+ *
+ * Use with #element_validate.
+ *
+ * @param $element
+ *   The form element. It is important that this is passed by reference so we
+ *   can update the element value if validation fails.
+ * @param $form_state
+ *   The form state.
+ * @param $form
+ *   The form.
+ */
+function _primo_textarea_map_validate(&$element, &$form_state, $form) {
+  foreach ($element['#value'] as $key => $value) {
+    if (empty($value) || empty($key)) {
+      form_error($element, t('Unable to extract mapping from element. Please ensure format is correct.'));
+      // When raising an error we have to manually convert our map back to a
+      // value suitable for the element. For some reason this does not work with
+      // $form_state.
+      $element['#value'] = _primo_textarea_map_value($element['#value']);
+      break;
+    }
+  };
 }
 
 /**

--- a/modules/primo/primo.module
+++ b/modules/primo/primo.module
@@ -45,6 +45,27 @@ function primo_ding_provider() {
 function primo_menu() {
   $items = array();
 
+  $items['admin/config/primo'] = array(
+    'title' => 'Primo',
+    'description' => 'Manage Primo integration settings.',
+    'position' => 'left',
+    'weight' => 20,
+    'page callback' => 'system_admin_menu_block_page',
+    'access arguments' => array('access administration pages'),
+    'file' => 'system.admin.inc',
+    'file path' => drupal_get_path('module', 'system'),
+  );
+
+  // This provides alternate access to provider settings.
+  $items['admin/config/primo/settings'] = array(
+    'title' => 'Provider settings',
+    'description' => 'Base settings for the Primo integration',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('primo_settings_form'),
+    'access arguments' => array('administer primo settings'),
+    'weight' => -1
+  );
+
   // We also provide a cover implementation. Add a shortcut to the settings form
   // under the cover settings as well.
   $items['admin/config/ting/covers/primo'] = array(
@@ -57,6 +78,17 @@ function primo_menu() {
   );
 
   return $items;
+}
+
+/**
+ * Implements hook_permission().
+ */
+function primo_permission() {
+  return array(
+    'administer primo settings' => array(
+      'title' => t('Administer Primo settings'),
+    ),
+  );
 }
 
 /**

--- a/modules/primo/src/Primo/BriefSearch/Client.php
+++ b/modules/primo/src/Primo/BriefSearch/Client.php
@@ -151,7 +151,7 @@ class Client {
 
     // If we're configured to search in a scope, add it.
     if (!empty($this->locationScopes)) {
-      $parameters[] = ['loc' => 'local,scope:(' . $this->locationScopes . ')'];
+      $queryParameters[] = ['loc' => 'local,scope:(' . $this->locationScopes . ')'];
     }
     try {
       $response = $this->httpClient->get('PrimoWebServices/xservice/search/brief', [

--- a/modules/primo/src/Primo/Ting/ObjectMapper.php
+++ b/modules/primo/src/Primo/Ting/ObjectMapper.php
@@ -80,7 +80,7 @@ class ObjectMapper {
     $object->setSubjects($this->mapSubjects());
     // TODO BBS-SAL: Implement getTracks() method.
     // TODO BBS-SAL: Implement getURI() method.
-    $object->setType($this->document->getType());
+    $object->setType($this->mapType());
     $object->setYear($this->document->getYear());
 
 
@@ -212,5 +212,17 @@ class ObjectMapper {
     // Primo returns subjects as a single string but Ding2 expects an array of
     // subject name strings. Explode by Primos delimiter.
     return explode(' ; ', $subjects);
+  }
+
+  /**
+   * Returns the type for the material.
+   *
+   * The returned value should preferably in a patron-friendly version.
+   *
+   * @return string
+   *  The material type.
+   */
+  public function mapType() {
+    return ValueMapper::mapMaterialTypeFromCode($this->document->getType());
   }
 }

--- a/modules/primo/src/Primo/Ting/PrimoStatementRenderer.php
+++ b/modules/primo/src/Primo/Ting/PrimoStatementRenderer.php
@@ -56,6 +56,10 @@ class PrimoStatementRenderer {
       'facet_genre' => function ($genre) {
         return ValueMapper::mapGenreToCode($genre);
       },
+      // Map material types back to codes.
+      'facet_rtype' => function($material_type) {
+        return ValueMapper::mapMaterialTypeToCode($material_type);
+      }
     ];
   }
 

--- a/modules/primo/src/Primo/Ting/Result.php
+++ b/modules/primo/src/Primo/Ting/Result.php
@@ -166,6 +166,9 @@ class Result implements TingSearchResultInterface {
         elseif ($facet->getId() === 'genre' && !empty($mapped = ValueMapper::mapGenreFromCode($name))) {
           $name = $mapped;
         }
+        elseif ($facet->getId() === 'rtype' && !empty($mapped = ValueMapper::mapMaterialTypeFromCode($name))) {
+          $name = $mapped;
+        }
 
         return new TingSearchFacetTerm($name, $frequency);
       }, array_keys($values), $values);

--- a/modules/primo/src/Primo/Ting/ValueMapper.php
+++ b/modules/primo/src/Primo/Ting/ValueMapper.php
@@ -115,6 +115,34 @@ class ValueMapper {
   }
 
   /**
+   * Maps primo material type codes to their mapped counterpart.
+   *
+   * @param string $code
+   *   The Primo code.
+   *
+   * @return string
+   *   The mapped code or the input code if it could not be mapped.
+   */
+  public static function mapMaterialTypeFromCode($code) {
+    $map = variable_get('primo_material_type_map', []);
+    return (!empty($map[$code])) ? $map[$code] : $code;
+  }
+
+  /**
+   * Maps material types to their mapped Primo code.
+   *
+   * @param string $material_type
+   *   The material type.
+   *
+   * @return string
+   *   The translated code or the input code if it could not be mapped.
+   */
+  public static function mapMaterialTypeToCode($material_type) {
+    $map = array_flip(variable_get('primo_material_type_map', []));
+    return (!empty($map[$material_type])) ? $map[$material_type] : $code;
+  }
+
+  /**
    * Reverse translation.
    *
    * "Translates" translated strings back to their source string.

--- a/modules/primo/src/Primo/Ting/ValueMapper.php
+++ b/modules/primo/src/Primo/Ting/ValueMapper.php
@@ -99,10 +99,11 @@ class ValueMapper {
    *   The Primo code.
    *
    * @return string
-   *   The translated code or the input code if it could not be mapped.
+   *   The mapped code or the input code if it could not be mapped.
    */
   public static function mapGenreFromCode($code) {
-    return t($code, [], ['context' => static::T_CONTEXT_GENRE]);
+    $map = variable_get('primo_genre_map', []);
+    return (!empty($map[$code])) ? $map[$code] : $code;
   }
 
   /**
@@ -111,7 +112,8 @@ class ValueMapper {
    * @return false|int|string
    */
   public static function mapGenreToCode($genre) {
-    return static::reverseTranslate($genre, static::T_CONTEXT_GENRE);
+    $map = array_flip(variable_get('primo_genre_map', []));
+    return (!empty($map[$genre])) ? $map[$genre] : $genre;
   }
 
   /**


### PR DESCRIPTION
This PR will add support for material type handling for Primo

It contains an administration interface for mapping material type ids to patron friendly strings.