### PR TITLE
Add track information. BBS-187

### DIFF
--- a/modules/primo/src/Primo/BriefSearch/Document.php
+++ b/modules/primo/src/Primo/BriefSearch/Document.php
@@ -299,4 +299,25 @@ class Document {
     return $node_values;
   }
 
+  /**
+   * Return a list of track names without the additional information.
+   *
+   * @return string[]
+   *   Track names.
+   */
+  public function getTracks() {
+    $nodes = $this->recordXpath($this->recordId, '//primo:search/primo:addtitle');
+
+    $result = array_map(function($track) {
+      // If addtitle contains "hljómdiskur" (CDs) or "mynddiskur" (DVD),
+      // ignore it.
+      if (preg_match('/hljómdiskur:|mynddiskur:/iu', $track)) {
+        return null;
+      }
+      return $track;
+    }, $this->nodeValues($nodes));
+
+    return array_filter($result);
+  }
+
 }

--- a/modules/primo/src/Primo/Ting/ObjectMapper.php
+++ b/modules/primo/src/Primo/Ting/ObjectMapper.php
@@ -78,7 +78,7 @@ class ObjectMapper {
     $object->setSeriesDescription($this->mapSeriesDescription());
     $object->setSource($this->mapSource());
     $object->setSubjects($this->mapSubjects());
-    // TODO BBS-SAL: Implement getTracks() method.
+    $object->setTracks($this->document->getTracks());
     // TODO BBS-SAL: Implement getURI() method.
     $object->setType($this->mapType());
     $object->setYear($this->document->getYear());


### PR DESCRIPTION
<img width="1300" alt="screen shot 2017-12-11 at 23 05 37" src="https://user-images.githubusercontent.com/514013/33856292-f01281e6-dec7-11e7-9ecb-9e699d5e5ff3.png">

**Ting object ID:** `ICE01_PRIMO_TEST001024912`

I tried to check other materials like DVD's and it seems like this is only available on `compactdisk` materials.