### PR TITLE
Add sites/all folder to shared directories

### DIFF
--- a/deploy.php
+++ b/deploy.php
@@ -17,6 +17,7 @@ set('npm', '/home/webmaster/bin/npm');
 set('drupal_site', 'default');
 set('shared_dirs', [
   'sites/{{drupal_site}}/files',
+  'sites/all',
 ]);
 set('shared_files', [
   'sites/{{drupal_site}}/settings.php',


### PR DESCRIPTION
BBS may want to download modules or themes directly to this folder.
This ensures that these modules are transferred properly between
releases.