### PR TITLE
BBS-143: Language title suffix

### DIFF
--- a/modules/ting/ting.admin.inc
+++ b/modules/ting/ting.admin.inc
@@ -51,7 +51,7 @@ function ting_admin_online_types_settings($form_state) {
   $form['update']['update'] = array(
     '#type' => 'submit',
     '#value' => t('Update'),
-    '#submit' => array('ting_admin_online_types_settings_update_types'),
+    '#submit' => array('ting_admin_type_source_update'),
   );
 
   $types = variable_get('ting_well_types', _ting_fetch_well_types());
@@ -111,13 +111,6 @@ function ting_admin_online_types_settings($form_state) {
 }
 
 /**
- * Submit handler. Updates the list of known types from the data well.
- */
-function ting_admin_online_types_settings_update_types($form, &$form_state) {
-  _ting_fetch_well_types();
-}
-
-/**
  * Form builder; Configure reservable materials.
  *
  * @ingroup forms
@@ -137,7 +130,7 @@ function ting_admin_reservable_settings($form_state) {
   $form['update']['update'] = array(
     '#type' => 'submit',
     '#value' => t('Update'),
-    '#submit' => array('ting_admin_reservable_settings_update'),
+    '#submit' => array('ting_admin_type_source_update'),
   );
 
   $form['reservation_settings'] = array(
@@ -204,7 +197,7 @@ function ting_admin_reservable_settings($form_state) {
  *
  * Updates the list of known types and sources from the data well.
  */
-function ting_admin_reservable_settings_update($form, &$form_state) {
+function ting_admin_type_source_update($form, &$form_state) {
   _ting_fetch_well_types();
   _ting_fetch_well_sources();
 }

--- a/modules/ting/ting.admin.inc
+++ b/modules/ting/ting.admin.inc
@@ -67,7 +67,7 @@ function ting_admin_online_types_settings($form_state) {
 
   $form['ting_online']['ting_online_types'] = array(
     '#type' => 'checkboxes',
-    '#options' => drupal_map_assoc(array_keys($types)),
+    '#options' => drupal_map_assoc($types),
     '#default_value' => variable_get('ting_online_types', _ting_default_online_types()),
   );
 
@@ -95,12 +95,11 @@ function ting_admin_online_types_settings($form_state) {
       '#description' => t("Here you may override the default label for individual material types."),
     );
 
-    foreach ($types as $term => $count) {
+    foreach ($types as $term) {
       $form['ting_url_labels']['types'][$term] = array(
         '#type' => 'textfield',
         '#title' => $term,
         '#default_value' => isset($settings[$term]) ? $settings[$term] : '',
-        '#description' => t('Count: @count', array('@count' => $count)),
         // Fudge the parent so we'll get all the labels in one big array in
         // ting_url_labels.
         '#parents' => array('ting_url_labels', $term),

--- a/modules/ting/ting.admin.inc
+++ b/modules/ting/ting.admin.inc
@@ -193,6 +193,62 @@ function ting_admin_reservable_settings($form_state) {
 }
 
 /**
+ * Form for managing language configuration.
+ *
+ * This configuration deals with how materials are handled depending on their
+ * language.
+ */
+function ting_admin_language_settings($form_state) {
+  $form['update'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Update from search provider'),
+    '#description' => t('Update the lists of known types.'),
+  );
+
+  $form['update']['update'] = array(
+    '#type' => 'submit',
+    '#value' => t('Update'),
+    '#submit' => array('ting_admin_type_source_update'),
+  );
+
+  $form['language'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Default language'),
+    '#tree' => FALSE,
+    '#collapsible' => TRUE,
+    '#collapsed' => FALSE,
+  );
+
+  // Note that this relies on a single global default language and not the user
+  // language or the like. We cannot expect that the material language and
+  // Drupal user language will be in the same format.
+  global $language;
+  $form['language']['ting_language_default'] = array(
+    '#type' => 'textfield',
+    '#default_value' => variable_get('ting_language_default', $language->native),
+    '#description' => t('The language expected to be used by most materials. Please use the full textual version of the language name as provided by your search provider.'),
+  );
+
+  $form['title_suffix'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Title suffix'),
+    '#tree' => FALSE,
+    '#collapsible' => TRUE,
+    '#collapsed' => FALSE,
+    '#description' => t("Select which material types should have the language appended as suffix."),
+  );
+
+  $types = variable_get('ting_well_types', _ting_fetch_well_types());
+  $form['title_suffix']['ting_language_type_title_suffix'] = array(
+    '#type' => 'checkboxes',
+    '#options' => drupal_map_assoc($types),
+    '#default_value' => variable_get('ting_language_type_title_suffix', []),
+  );
+
+  return system_settings_form($form);
+}
+
+/**
  * Submit handler.
  *
  * Updates the list of known types and sources from the data well.

--- a/modules/ting/ting.field.inc
+++ b/modules/ting/ting.field.inc
@@ -391,23 +391,15 @@ function ting_field_formatter_view($entity_type, $entity, $field, $instance, $la
           $title = check_plain($title);
         }
 
-        // TODO BBS-SAL: Refactor this to a general setting that allows the
-        // administrator to choose a list of material-types that should have
-        // the language added to the title if the material is not in the site
-        // default language. Add a ting_default_material_language variable and
-        // add it to ting.admin.inc.
-        $is_book = '';
-        if (isset($entity)) {
-          $_string = $entity->type;
-
-          if (isset($_string) && preg_match('~\bBog\b~', $_string) != FALSE) {
-            $is_book = TRUE;
-          }
-
-          $lang = $entity->getLanguage();
-          if ($is_book && $lang != 'Dansk') {
-            $title = $title . ' (' . $lang . ')';
-          }
+        // Append the language as a suffix to the title for certain material
+        // types if the material language is not the default language.
+        /* @var \TingEntity $entity */
+        $title_suffix_types = variable_get('ting_language_type_title_suffix', []);
+        $default_language = variable_get('ting_language_default');
+        $is_title_suffix_type = in_array($entity->getType(), $title_suffix_types);
+        $is_default_language = $entity->getLanguage() == $default_language;
+        if ($is_title_suffix_type && !$is_default_language) {
+          $title .= " ($language)";
         }
 
         $element[$delta] = array(

--- a/modules/ting/ting.install
+++ b/modules/ting/ting.install
@@ -286,3 +286,18 @@ function ting_update_7012() {
     }
   }, $var_names);
 }
+
+/**
+ * Configure book types to have non-default languages shown as title suffix.
+ */
+function ting_update_7013() {
+  variable_set('ting_language_default', 'Dansk');
+
+  $language_suffix_types = array_filter(
+    _ting_fetch_well_types(),
+    function($type) {
+      return (bool) preg_match('/\bBog\b/i', $type);
+    }
+  );
+  variable_set('ting_language_type_title_suffix', $language_suffix_types);
+}

--- a/modules/ting/ting.module
+++ b/modules/ting/ting.module
@@ -117,6 +117,15 @@ function ting_menu() {
     'file' => 'ting.admin.inc',
   );
 
+  $items['admin/config/ting/language'] = array(
+    'title' => 'Language',
+    'description' => 'Configure how languages affect Ting objects.',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('ting_admin_language_settings'),
+    'access arguments' => array('administer ting settings'),
+    'file' => 'ting.admin.inc',
+  );
+
   return $items;
 }
 


### PR DESCRIPTION
The current language title suffix is hardcoded to Danish: Strings "Dansk" and "bog" are used.

This PR will make the display of language as a title suffix configurable. This will make the functionality usable across search systems and languages.

Example when using "Engelsk" as the default language:

![search ting harry potter page 3 ding2 docker 2018-01-08 13-56-53](https://user-images.githubusercontent.com/73966/34671690-ccb6422c-f47b-11e7-905b-b4ca8d76e0aa.png)

BBS-143.