### PR TITLE
BBS-157: Move most generic sorting options to Opensearch provider

### DIFF
--- a/modules/opensearch/includes/opensearch.search.inc
+++ b/modules/opensearch/includes/opensearch.search.inc
@@ -543,7 +543,32 @@ function opensearch_search_prepare_reference_query($query_string) {
  *   instance. Keyed by a machine-name.
  */
 function opensearch_search_sort_options() {
-  $options = [];
+  $options = [
+    'title_ascending' => [
+      'label' => t('Title (Ascending)'),
+      'sort' => new TingSearchSort(TingSearchCommonFields::TITLE, TingSearchSort::DIRECTION_ASCENDING),
+    ],
+      'title_descending' => [
+      'label' => t('Title (Descending)'),
+      'sort' => new TingSearchSort(TingSearchCommonFields::TITLE, TingSearchSort::DIRECTION_DESCENDING),
+    ],
+      'creator_ascending' => [
+      'label' => t('Creator (Ascending)'),
+      'sort' => new TingSearchSort(TingSearchCommonFields::AUTHOR, TingSearchSort::DIRECTION_ASCENDING),
+    ],
+      'creator_descending' => [
+      'label' => t('Creator (Descending)'),
+      'sort' => new TingSearchSort(TingSearchCommonFields::AUTHOR, TingSearchSort::DIRECTION_DESCENDING),
+    ],
+      'date_ascending' => [
+      'label' => t('Date (Ascending)'),
+      'sort' => new TingSearchSort(TingSearchCommonFields::DATE, TingSearchSort::DIRECTION_ASCENDING),
+    ],
+      'date_descending' => [
+      'label' => t('Date (Descending)'),
+      'sort' => new TingSearchSort(TingSearchCommonFields::DATE, TingSearchSort::DIRECTION_DESCENDING),
+    ]
+  ];
 
   // TODO BBS-SAL: Test.
   // Add Acquisition Date sort for opensearch v4.3 or higher.

--- a/modules/ting_search/ting_search.module
+++ b/modules/ting_search/ting_search.module
@@ -913,30 +913,6 @@ function ting_search_sort_options() {
       'label' => t('Ranking'),
       'sort' => NULL,
     ],
-    'title_ascending' => [
-      'label' => t('Title (Ascending)'),
-      'sort' => new TingSearchSort(TingSearchCommonFields::TITLE, TingSearchSort::DIRECTION_ASCENDING),
-    ],
-    'title_descending' => [
-      'label' => t('Title (Descending)'),
-      'sort' => new TingSearchSort(TingSearchCommonFields::TITLE, TingSearchSort::DIRECTION_DESCENDING),
-    ],
-    'creator_ascending' => [
-      'label' => t('Creator (Ascending)'),
-      'sort' => new TingSearchSort(TingSearchCommonFields::AUTHOR, TingSearchSort::DIRECTION_ASCENDING),
-    ],
-    'creator_descending' => [
-      'label' => t('Creator (Descending)'),
-      'sort' => new TingSearchSort(TingSearchCommonFields::AUTHOR, TingSearchSort::DIRECTION_DESCENDING),
-    ],
-    'date_ascending' => [
-      'label' => t('Date (Ascending)'),
-      'sort' => new TingSearchSort(TingSearchCommonFields::DATE, TingSearchSort::DIRECTION_ASCENDING),
-    ],
-    'date_descending' => [
-      'label' => t('Date (Descending)'),
-      'sort' => new TingSearchSort(TingSearchCommonFields::DATE, TingSearchSort::DIRECTION_DESCENDING),
-    ],
   ];
 
   // Add provider sorts.


### PR DESCRIPTION
It turns out we cannot expect much in regards to default sorting from
Primo so move the ones we thought we generic to Opensearch and let each
provider be on its own.

BBS-157