### PR TITLE
BBS-157: Implement Primo sorting

### DIFF
--- a/modules/primo/includes/primo.search.inc
+++ b/modules/primo/includes/primo.search.inc
@@ -10,7 +10,9 @@ use Primo\Ting\Collection;
 use Primo\Ting\PrimoStatementRenderer;
 use Primo\Ting\Result;
 use Ting\Search\SearchProviderException;
+use Ting\Search\TingSearchCommonFields;
 use Ting\Search\TingSearchRequest;
+use Ting\Search\TingSearchSort;
 
 // TODO Remove this once Primo search provider is fully implemented.
 // Ding does not support mixing multiple partial implementations of a provider
@@ -184,9 +186,19 @@ function primo_search_search(TingSearchRequest $ting_query) {
   $page = $ting_query->getPage();
   $count = $ting_query->getCount();
 
+  // Empty sort string means default relevance sort is used.
+  $sort_string = NULL;
+  $sorts = $ting_query->getSorts());
+  if (!empty($sorts)) {
+    // Primo only supports a single sort order. The field name includes the
+    // sort direction so extract and use the first one. Ignore the rest.
+    $sort = array_shift($sorts);
+    $sort_string = $sort->getField();
+  }
+
   // Execute the search, return the result.
   try {
-    $primo_result = $client->search($queries, $page, $count);
+    $primo_result = $client->search($queries, $page, $count, $sort);
     $result = new Result($primo_result, $ting_query);
 
     // Pre-warm the cache so that subsequent loads of objects for the documents
@@ -311,7 +323,30 @@ function primo_search_prepare_reference_query($query_string) {
  *   instance. Keyed by a machine-name.
  */
 function primo_search_sort_options() {
-  return opensearch_search_sort_options();
+  // For Primo the direction is a part of the field name so we do not need to
+  // set it. Default direction NONE is fine.
+  return [
+    'title' => [
+      'label' => t('Title'),
+      'sort' => new TingSearchSort('stitle'),
+    ],
+    'creator' => [
+      'label' => t('Creator'),
+      'sort' => new TingSearchSort('screator'),
+    ],
+    'date_descending' => [
+      'label' => t('Date (Descending)'),
+      'sort' => new TingSearchSort('scdate'),
+    ],
+    'date_ascending' => [
+      'label' => t('Date (Ascending)'),
+      'sort' => new TingSearchSort('scdate2'),
+    ],
+    'popularity' => [
+      'label' => t('Popularity'),
+      'sort' => new TingSearchSort('popularity'),
+    ]
+  ];
 }
 
 /**

--- a/modules/primo/src/Primo/BriefSearch/Client.php
+++ b/modules/primo/src/Primo/BriefSearch/Client.php
@@ -134,6 +134,9 @@ class Client {
    *   The offset of the search results to return. Use 1 for the first result.
    * @param int $numResults
    *   The number of results to return.
+   * @param string $sort
+   *   Specifies the type of sort to perform. If this parameter is not specified
+   *   or left empty, the system uses the relevance sort.
    *
    * @return \Primo\BriefSearch\Result
    *   The search result.
@@ -141,10 +144,11 @@ class Client {
    * @throws \Primo\Exception\TransferException
    *   If an error occurs during the execution of the search.
    */
-  public function search(array $queryParameters, $offset, $numResults) {
+  public function search(array $queryParameters, $offset, $numResults, $sort = NULL) {
     // Set user-specified "runtime" values.
     $queryParameters['indx'] = [$offset];
     $queryParameters['bulkSize'] = [$numResults];
+    $queryParameters['sortField'] = [$sort];
 
     // Add in "static" defaults.
     $queryParameters = array_merge_recursive($queryParameters, $this->defaultParameters);


### PR DESCRIPTION
This PR adds sort support to Primo client and implements proper Ding2 sorting options.

It is dependant on #158 being merged.

