### PR TITLE
Fix expiry date

### DIFF
--- a/modules/aleph/src/Aleph/AlephClient.php
+++ b/modules/aleph/src/Aleph/AlephClient.php
@@ -138,19 +138,27 @@ class AlephClient {
    *   Patron ID.
    * @param string $verification
    *   Patron PIN.
+   * @param string $sub_library
+   *   The branch/sublibrary to authenticate against.
    *
    * @return \SimpleXMLElement
    *   The authentication response from Aleph or error message.
    *
    * @throws AlephClientException
    */
-  public function authenticate($bor_id, $verification) {
-    $response = $this->request('GET', 'bor-auth', array(
+  public function authenticate($bor_id, $verification, $sub_library = '') {
+    if (!empty($sub_library)) {
+      return $this->request('GET', 'bor-auth', array(
+        'bor_id' => $bor_id,
+        'verification' => $verification,
+        'sub_library' => $sub_library,
+      ));
+    }
+
+    return $this->request('GET', 'bor-auth', array(
       'bor_id' => $bor_id,
       'verification' => $verification,
     ));
-
-    return $response;
   }
 
   /**

--- a/modules/aleph/src/Aleph/Handler/AlephPatronHandler.php
+++ b/modules/aleph/src/Aleph/Handler/AlephPatronHandler.php
@@ -59,6 +59,9 @@ class AlephPatronHandler extends AlephHandlerBase {
    */
   public function authenticate($bor_id, $verification, array $allowed_login_branches = []) {
     $response = $this->client->authenticate($bor_id, $verification);
+    // Sub library is hardcoded in order to show correct expiry date.
+    // Most users are active in the BBAAA branch.
+    $response_sub_library = $this->client->authenticate($bor_id, $verification, 'BBAAA');
 
     $result = new AuthenticationResult(
       $this->client, $bor_id, $verification, $allowed_login_branches,
@@ -71,7 +74,7 @@ class AlephPatronHandler extends AlephHandlerBase {
       $patron->setVerification($verification);
       $patron->setName((string) $response->xpath('z303/z303-name')[0]);
       $patron->setEmail((string) $response->xpath('z304/z304-email-address')[0]);
-      $patron->setExpiryDate((string) $response->xpath('z305/z305-expiry-date')[0]);
+      $patron->setExpiryDate((string) $response_sub_library->xpath('z305/z305-expiry-date')[0]);
       $patron->setPhoneNumber((string) $response->xpath('z304/z304-telephone')[0]);
       $this->setPatron($patron);
       $result->setPatron($patron);


### PR DESCRIPTION
Aleph shows the wrong expiry date if the request to bor_auth is without sub_library, however we're not interested in users unable to login because they are not active in a specific branch.

Björn said most users are active in BBAAA, so we'll always use that expiry date.

BBS-250