### PR TITLE
Update Primo to use renamed SAL function to retrieve filters 

### DIFF
--- a/modules/primo/includes/primo.search.inc
+++ b/modules/primo/includes/primo.search.inc
@@ -173,7 +173,7 @@ function primo_search_search(TingSearchRequest $ting_query) {
   }
 
   // Handle filters.
-  if (!empty($field_filters = $ting_query->getFieldFilters())) {
+  if (!empty($field_filters = $ting_query->getFilters())) {
     $renderer = new PrimoStatementRenderer(_primo_common_field_mapping());
     $queries = array_merge_recursive($queries, $renderer->renderStatements($field_filters));
   }


### PR DESCRIPTION
Otherwise our code will fail because an unknown method is called.
The method was renamed in release 4.3.0-rc1. See
https://github.com/ding2/ding2/commit/db7585568e742de62eacd1126796afb52ef01736