### PR TITLE
Use 8 min characters in login pwd field

### DIFF
--- a/modules/ding_user_form/ding_user_form.module
+++ b/modules/ding_user_form/ding_user_form.module
@@ -1,5 +1,7 @@
 <?php
 
+use Alma\Users\Client as UserClient;
+
 /**
  * @file
  * Handle user login form changes.
@@ -50,8 +52,8 @@ function ding_user_form_form_alter(&$form, $form_state, $form_id) {
       // Hide titles, and add display as placeholders.
       $form['name']['#attributes']['placeholder'] = t('Loan/social security number (without dash)');
       $form['name']['#title_display'] = 'invisible';
-      $form['pass']['#attributes']['placeholder'] = t('Pincode (@length digits)',
-        ['@length' => ding_user_get_pincode_length_range_string()]);
+      $form['pass']['#attributes']['placeholder'] = t('Password (min. @length characters)',
+        ['@length' => UserClient::MIN_PASSWORD_LENGTH ]);
       $form['pass']['#title_display'] = 'invisible';
 
       // Add our own validation handler, after the default Drupal login


### PR DESCRIPTION

#### Link to issue

https://reload.atlassian.net/browse/BBS-671

#### Description

Since the requirements/validation has changed on passwords the English text in the placeholder of the password field need to be changed correspondingly.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

