### PR TITLE
Fix operand issue in override_node_options_form_alter

### DIFF
--- a/ding2.make
+++ b/ding2.make
@@ -337,7 +337,7 @@ projects[opening_hours][patch][] = "https://www.drupal.org/files/issues/opening_
 projects[opening_hours][patch][] = "https://www.drupal.org/files/issues/opening-hours-2820005-hide-field-if-empty.patch"
 
 projects[override_node_options][subdir] = "contrib"
-projects[override_node_options][version] = "1.13"
+projects[override_node_options][version] = "1.15"
 
 projects[pagepreview][subdir] = "contrib"
 projects[pagepreview][version] = "1.0-alpha1"


### PR DESCRIPTION

#### Link to issue

https://reload.atlassian.net/browse/BBS-681

#### Description

By upgrading override_node_options to 1.15 we do not get the error and editors are able to create content.
Issue:
https://www.drupal.org/project/override_node_options/issues/3274297

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

