### PR TITLE
Download Leaflet from GitHub instead of cdn.leafletjs.com

### DIFF
--- a/ding2.make
+++ b/ding2.make
@@ -578,7 +578,7 @@ libraries[jsonmapper][destination] = "libraries"
 libraries[leaflet][type] = "library"
 libraries[leaflet][download][type] = "get"
 libraries[leaflet][download][url] = "https://github.com/Leaflet/Leaflet/archive/refs/tags/v0.7.3.zip"
-libraries[leaflet][download][subtree] = "dist"
+libraries[leaflet][download][subtree] = "Leaflet-0.7.3/dist"
 libraries[leaflet][directory_name] = "leaflet"
 libraries[leaflet][destination] = "libraries"
 

--- a/ding2.make
+++ b/ding2.make
@@ -577,7 +577,8 @@ libraries[jsonmapper][destination] = "libraries"
 ; For leaflet.
 libraries[leaflet][type] = "library"
 libraries[leaflet][download][type] = "get"
-libraries[leaflet][download][url] = "http://cdn.leafletjs.com/downloads/leaflet-0.7.3.zip"
+libraries[leaflet][download][url] = "https://github.com/Leaflet/Leaflet/archive/refs/tags/v0.7.3.zip"
+libraries[leaflet][download][subtree] = "dist"
 libraries[leaflet][directory_name] = "leaflet"
 libraries[leaflet][destination] = "libraries"
 


### PR DESCRIPTION
#### Description

cdn.leafletjs.com is no longer available causing our build to break with the following error:

```
#17 89.38 Unable to download leaflet from                                      [error]
#17 89.38 http://cdn.leafletjs.com/downloads/leaflet-0.7.3.zip
```

Downloading the build from GitHub should be more reliable.

To achieve this we have to use the subtree feature of Drush Make since this is placed within a subdirectory of the asset.
